### PR TITLE
Feature/text keyword map

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,45 @@ Could have a config like such:
   ]
  }
 ```
+In Elasticsearch, the fields will be
+```
+assay,json|rna|primer
+assay,json|single_cell|method
+assay,json|sra_experiment
+assay,json|files|format
+cell,json|type
+cell,json|ontology
+cell,json|id
+```
+Notice the commas(,) where there were previously periods(.). Also, the pipe (|) is used as the separator between levels in the config.
+
+#### Adding Mappings
+Given a config:
+```
+{
+  "cell.json":[
+    "type",
+    "ontology",
+    "id"
+  ]
+ }
+```
+The default mapping is `keyword`. 
+However, in the `chalicelib/config.json` the mapping can be specified. For example:
+```
+{
+  "cell.json":[
+    "type*keyword",
+    "ontology*keyword*text",
+    "id*keyword*text_autocomplete"
+  ]
+ }
+```
+The field `cell,json|type` will have a mapping of `keyword`.
+The field `cell,json|ontology` will have a mapping of `keyword` but `cell,json|ontology.raw` has a mapping of `text`
+The field `cell,json|id` will have a mapping of `keyword` but `cell,json|id.raw` has a mapping of `text` with an analyzer of `autocomplete`
+The analyzers can be defined in `chalicelib/settings.json`
+Other mappings are also allowed (ie: `long`). However, if using both `keyword` and `text` please put `keyword` before `text` (ie: `ontology*keyword*text` not `ontology*text*keyword`)
 
 ### Environmental Variables
 In order to add environmental variables to Chalice, the variables must be added to three locations.

--- a/app.py
+++ b/app.py
@@ -102,7 +102,7 @@ def es_config(c_item, name):
                 name = str(name) + "|" + str(key)
             else:
                 name = str(key)
-            # recursively call function on each item in this level of config values
+            # recursively call on each item in this level of config values
             for item in value:
                 es_array.append(es_config(item, name))
             return es_array
@@ -173,19 +173,16 @@ for item in key_names:
                               "fields": {"raw": {"type": i_split[2]}}}})
         elif len(u_split) == 1 and len(banana_split) == 2:
             # ex: name*mapping1*mapping2_analyzer
-            es_mappings.append(
-                {i_split[0]: {"type": i_split[1],
-                              "fields": {"raw": {"type": banana_split[0],
-                                                 "analyzer": banana_split[1],
-                                                 "search_analyzer": "standard"}}}})
+            es_mappings.append({i_split[0]: {"type": i_split[1], "fields": {
+                "raw": {"type": banana_split[0], "analyzer": banana_split[1],
+                        "search_analyzer": "standard"}}}})
         elif len(u_split) == 2 and len(banana_split) == 2:
             # ex: name*mapping1_analyzer*mapping2_analyzer
-            es_mappings.append(
-                {i_split[0]: {"type": u_split[0], "analyzer": u_split[1],
-                              "search_analyzer": "standard",
-                              "fields": {"raw": {"type": banana_split[0],
-                                                 "analyzer": banana_split[1],
-                                                 "search_analyzer": "standard"}}}})
+            es_mappings.append({i_split[0]: {"type": u_split[0], "fields": {
+                "raw": {"type": banana_split[0], "analyzer": banana_split[1],
+                        "search_analyzer": "standard"}},
+                                             "analyzer": u_split[1],
+                                             "search_analyzer": "standard"}})
         else:
             app.log.info("mapping formatting problem %s", i_split)
 
@@ -243,12 +240,12 @@ def get_bundles(bundle_uuid):
     :return: json file with items separated by json files and data files
     """
     app.log.info("get_bundle %s", bundle_uuid)
-    #    try:
-    #        json_str = urlopen(str(bb_host+('v1/bundles/')+bundle_uuid)).read()
-    #        bundle = json.loads(json_str)
-    #    except Exception as e:
-    #        app.log.info(e)
-    #        raise NotFoundError("Bundle '%s' does not exist" % bundle_uuid)
+    # try:
+    #    json_str = urlopen(str(bb_host+('v1/bundles/')+bundle_uuid)).read()
+    #    bundle = json.loads(json_str)
+    # except Exception as e:
+    #    app.log.info(e)
+    #    raise NotFoundError("Bundle '%s' does not exist" % bundle_uuid)
 
     # the blue box may have trouble returning bundle, so retry 3 times
     retries = 0
@@ -284,7 +281,6 @@ def get_bundles(bundle_uuid):
         if file["name"].endswith(".json"):
             json_files.append({file["name"]: file["uuid"]})
         else:
-            # data_files.append({file["name"]: file["uuid"]}) CARLOS REMOVED THIS
             data_files.append({file["name"]: file})
     return json.dumps({'json_files': json_files, 'data_files': data_files})
 
@@ -331,7 +327,7 @@ def write_index(bundle_uuid):
         raise NotFoundError("Bundle '%s' does not exist" % bundle_uuid)
     bundle = json.loads(bundle_url)
     # bundle = json.loads(get_bundles(bundle_uuid))
-    fcount = len(bundle['data_files'])
+    # fcount = len(bundle['data_files'])
     json_files = bundle['json_files']
     # open config file
     try:
@@ -422,7 +418,8 @@ def config_thread(c_key, c_value, json_files, file_uuid, es_json):
         # if the config (file name) is in the given json file
         if c_key in json_files[j]:
             try:
-                # file_url = urlopen(str(in_host+'/file/' + json_files[j][c_key])).read()
+                # file_url = urlopen(
+                #     str(in_host + '/file/' + json_files[j][c_key])).read()
                 file_url = get_file(json_files[j][c_key])
                 file = json.loads(file_url)
             except Exception as e:
@@ -497,7 +494,9 @@ def look_file(c_item, file, name):
     elif c_item.split("*")[0] not in file:
         # all config items that cannot be found in file are given value "None"
         c_item_split = c_item.split("*")
-        file_value = "None"  # Putting an empty string. I think if I put None (instead of "None") it could break things downstream
+        # Putting an empty string.
+        # If None (instead of "None") it could break things downstream
+        file_value = "None"
         name = str(name) + "|" + str(c_item_split[0])
         # ES does not like periods(.) use commas(,) instead
         n_replace = name.replace(".", ",")

--- a/app.py
+++ b/app.py
@@ -247,8 +247,7 @@ def get_bundles(bundle_uuid):
     while retries < 3:
         try:
             # call the blue box
-            json_str = urlopen(
-                str(bb_host + ('v1/bundles/') + bundle_uuid)).read()
+            json_str = urlopen(str(bb_host + ('v1/bundles/') + bundle_uuid + "?replica=aws")).read()
             # json load string for processing later
             bundle = json.loads(json_str)
             break
@@ -359,6 +358,7 @@ def write_index(bundle_uuid):
         file_name, values = list(_file.items())[0]
         file_uuid = values['uuid']
         file_version = values['version']
+        file_size = values['size']
         # Make the ES uuid be a concatenation of:
         # bundle_uuid:file_uuid:file_version
         es_uuid = "{}:{}:{}".format(bundle_uuid, file_uuid, file_version)
@@ -429,8 +429,8 @@ def write_index(bundle_uuid):
             es_json.append({'bundle_type': 'scRNA-Seq Upload'})
         else:
             es_json.append({'bundle_type': 'Unknown'})
-        # fake file size
-        es_json.append({'file_size': 500000})
+        # adding size of the file
+        es_json.append({'file_size': file_size})
         # Carlos using set theory to handle non-present keys
         all_keys = es_file.keys()
         present_keys = [list(x.keys())[0] for x in es_json]

--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ import collections
 import re
 from multiprocessing import Process
 import threading
+import queue
 # import random
 
 
@@ -304,6 +305,7 @@ def get_file(file_uuid):
     except Exception as e:
         app.log.info(e)
         raise NotFoundError("File '%s' does not exist" % file_uuid)
+    #queue.put(json.dumps(file))
     return json.dumps(file)
 
 
@@ -533,20 +535,28 @@ def cron_look():
         bundle_mod = item['bundle_id'][:-26]
         app.log.info(bundle_mod)
         bundle_ids.append(bundle_mod)
-        thread = threading.Thread(target=write_index, args=(bundle_mod,))
-        threads.append(thread)
+        process = Process(target=make_thread, args=(bundle_mod,))
+        # thread = threading.Thread(target=write_index, args=(bundle_mod,))
+        # threads.append(thread)
         # process = Process(target=write_index, args=(bundle_mod,))
-        # processes.append(process)
-    # # start all processes
-    # for process in processes:
-    #     process.start()
-    # # make sure that all processes have finished
-    # for process in processes:
-    #     process.join()
-    for thread in threads:
-        thread.start()
-    for thread in threads:
-        thread.join()
+        processes.append(process)
+        process.start()
+    # make sure that all processes have finished
+    for process in processes:
+        process.join()
+    # for thread in threads:
+    #     thread.start()
+    # for thread in threads:
+    #     thread.join()
     app.log.info({"bundle_id": bundle_ids})
     #return {"bundle_id": bundle_ids}
-    return {"Cron":"done"}
+    return {"cron_bundle_ids": bundle_ids}
+
+def make_thread(bundle_mod):
+    app.log.info ("make_thread"+bundle_mod)
+    thread = threading.Thread(target=write_index, args=(bundle_mod,))
+    thread.start()
+    thread.join()
+    return thread
+
+

--- a/chalicelib/config.json
+++ b/chalicelib/config.json
@@ -2,7 +2,7 @@
   "assay.json": [
     {
       "single_cell": [
-        "cell_handling*keyword"
+        "cell_handling"
       ]
     },
     {
@@ -23,7 +23,7 @@
     "id",
     {
       "submitter": [
-        "name*keyword*text_autocomplete",
+        "name",
         "institution",
         "country"
       ]
@@ -32,14 +32,14 @@
   "sample.json": [
     {
       "body_part": [
-        "text*keyword*text_autocomplete"
+        "text"
       ]
     },
     {
       "donor": [
         {
           "species": [
-            "text*keyword*text_autocomplete",
+            "text",
             "ontology"
           ]
         },
@@ -54,13 +54,13 @@
     "name",
     {
       "organ": [
-        "text*keyword*text_autocomplete"
+        "text"
       ]
     },
     "project_id",
     {
       "cell_cycle": [
-        "text*keyword*text_autocomplete"
+        "text"
       ]
     },
     "culture_type",

--- a/chalicelib/config.json
+++ b/chalicelib/config.json
@@ -23,7 +23,7 @@
     "id",
     {
       "submitter": [
-        "name*text_autocomplete",
+        "name*keyword*text_autocomplete",
         "institution",
         "country"
       ]
@@ -32,14 +32,14 @@
   "sample.json": [
     {
       "body_part": [
-        "text"
+        "text*keyword*text_autocomplete"
       ]
     },
     {
       "donor": [
         {
           "species": [
-            "text*text",
+            "text*keyword*text_autocomplete",
             "ontology"
           ]
         },
@@ -60,7 +60,7 @@
     "project_id",
     {
       "cell_cycle": [
-        "text*text_autocomplete*keyword"
+        "text*keyword*text_autocomplete"
       ]
     },
     "culture_type",

--- a/chalicelib/config.json
+++ b/chalicelib/config.json
@@ -2,7 +2,7 @@
   "assay.json": [
     {
       "single_cell": [
-        "cell_handling"
+        "cell_handling*keyword"
       ]
     },
     {
@@ -23,7 +23,7 @@
     "id",
     {
       "submitter": [
-        "name",
+        "name*text_autocomplete",
         "institution",
         "country"
       ]
@@ -39,7 +39,7 @@
       "donor": [
         {
           "species": [
-            "text",
+            "text*text",
             "ontology"
           ]
         },
@@ -54,13 +54,13 @@
     "name",
     {
       "organ": [
-        "text"
+        "text*keyword*text_autocomplete"
       ]
     },
     "project_id",
     {
       "cell_cycle": [
-        "text"
+        "text*text_autocomplete*keyword"
       ]
     },
     "culture_type",

--- a/chalicelib/settings.json
+++ b/chalicelib/settings.json
@@ -1,0 +1,22 @@
+{
+    "analysis": {
+        "filter": {
+            "autocomplete_filter": {
+                "type": "ngram",
+                "min_gram": 1,
+                "max_gram": 36
+            }
+        },
+        "analyzer": {
+            "autocomplete": {
+                "type": "custom",
+                "tokenizer": "keyword",
+                "filter": [
+                    "lowercase",
+                    "autocomplete_filter"
+                ]
+            }
+        }
+    }
+}
+

--- a/test/test_flask.py
+++ b/test/test_flask.py
@@ -1,0 +1,399 @@
+from flask import Flask, jsonify
+app = Flask(__name__)
+
+# this is a flask mock-up of the blue box and used for testing purposes
+
+@app.route('/')
+def hello_world():
+    return 'Hello, World!'
+
+@app.route('/v1/bundles/<bundle_uuid>')
+def give_bundle(bundle_uuid):
+    return jsonify(
+        {
+            "bundle": {
+                "creator_uid": 1,
+                "files": [
+                    {
+                        "content-type": "application/json",
+                        "crc32c": "bb52aea3",
+                        "indexed": True,
+                        "name": "assay.json",
+                        "s3_etag": "345f3c5065d77925d2aceff03de276b3",
+                        "sha1": "b7132ca4a56bcee6469266f6ef612c3b3bbbc52c",
+                        "sha256": "3d7d562856984cb1d8d378618baaa94b3cc44988b899d2838018bf947b8d7cb8",
+                        "uuid": "c1fb1206-7c6a-408c-b056-91eedb3f7a19",
+                        "version": "2017-09-22T001550.273020Z"
+                    },
+                    {
+                        "content-type": "gzip",
+                        "crc32c": "e68855a7",
+                        "indexed": True,
+                        "name": "ERR580157_1.fastq.gz",
+                        "s3_etag": "e771bab4b85e09b9a714f53b2fca366f",
+                        "sha1": "99c3ea974678720f1159fe61f77d958bb533bd7d",
+                        "sha256": "c4d20c2d5e6d8276f96d7a9dc4a8df1650a2b34d70d0f775f35a174035fa4141",
+                        "uuid": "52d4f049-2c9a-4a75-8dd4-9559902e67bd",
+                        "version": "2017-09-22T001551.542119Z"
+                    },
+                    {
+                        "content-type": "gzip",
+                        "crc32c": "ee751fc7",
+                        "indexed": True,
+                        "name": "ERR580157_2.fastq.gz",
+                        "s3_etag": "15d80faa6b78463c2bd9e8789b0a3d25",
+                        "sha1": "b143f054b564c31f72f51b66d28bb922a0c0317d",
+                        "sha256": "91f33631ff0b30c0cd1e06489436a0e6944eec205338f10bf979b179b3fbb919",
+                        "uuid": "cd6c128b-cf1f-49dc-b3d8-1eb39115f90e",
+                        "version": "2017-09-22T001552.608139Z"
+                    },
+                    {
+                        "content-type": "application/json",
+                        "crc32c": "c155a99c",
+                        "indexed": True,
+                        "name": "project.json",
+                        "s3_etag": "0cefbf7e03412a031ece2e337716eb49",
+                        "sha1": "ff010c9c38c6db711c8534db11587a98a95ef5cf",
+                        "sha256": "fc13c24cd7b9c3f3bb378f874c81573a5edb617078c6c1ab533fc9724d5c57ee",
+                        "uuid": "d1bf1d60-7aaf-44c4-b8be-52180ac98535",
+                        "version": "2017-09-22T001553.697403Z"
+                    },
+                    {
+                        "content-type": "application/json",
+                        "crc32c": "91bb5ad5",
+                        "indexed": True,
+                        "name": "sample.json",
+                        "s3_etag": "6778129b17287d80d2bd85695cdf5bd0",
+                        "sha1": "0af94780add752c632f6e8531b6c661d8eec5ef0",
+                        "sha256": "6135e1f93b8b6536f4893c31419d2640b0fd0d1eea927b5e1c8690739f00646e",
+                        "uuid": "328229b7-5a5a-43fc-84d4-c3071d6e2d57",
+                        "version": "2017-09-22T001554.790410Z"
+                    }
+                ],
+                "uuid": "b1db2bf9-855a-4961-ae39-be2a8d6aa864",
+                "version": "2017-09-22T001555.857860Z"
+            }
+        }
+    )
+
+
+@app.route('/v1/files/c1fb1206-7c6a-408c-b056-91eedb3f7a19')
+def give_file_assay():
+    return jsonify(
+        {
+            "core": {
+                "type": "assay",
+                "schema_version": "3.0.0",
+                "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/assay.json"
+            },
+            "rna": {
+                "core": {
+                    "type": "rna",
+                    "schema_version": "3.0.0",
+                    "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/rna.json"
+                },
+                "end_bias": "full_transcript",
+                "primer": "random",
+                "library_construction": "SMARTer Ultra Low RNA Kit",
+                "spike_in": "ERCC"
+            },
+            "seq": {
+                "core": {
+                    "type": "seq",
+                    "schema_version": "3.0.0",
+                    "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/seq.json"
+                },
+                "instrument_model": "Illumina HiSeq 2000",
+                "instrument_platform": "Illumina",
+                "library_construction": "Nextera XT",
+                "molecule": "RNA",
+                "paired_ends": "yes",
+                "lanes": [
+                    {
+                        "number": 1,
+                        "r1": "ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR580/ERR580157/ERR580157_1.fastq.gz",
+                        "r2": "ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR580/ERR580157/ERR580157_2.fastq.gz"
+                    }
+                ],
+                "ena_experiment": "ERX538284",
+                "ena_run": "ERR580157"
+            },
+            "single_cell": {
+                "core": {
+                    "type": "single_cell",
+                    "schema_version": "3.0.0",
+                    "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/single_cell.json"
+                },
+                "cell_handling": "Fluidigm C1"
+            },
+            "sample_id": "d3abdd56-8d52-44d9-938b-f349e827e06e",
+            "id": "c8899599-4d25-416a-96bd-2c22c54a0c25"
+        }
+    )
+
+@app.route('/v1/files/d1bf1d60-7aaf-44c4-b8be-52180ac98535')
+def give_file_project():
+    return jsonify(
+        {
+            "core": {
+                "type": "project",
+                "schema_version": "3.0.0",
+                "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/project.json"
+            },
+            "title": "Gene expression pattern of single mES cells during cell cycle stages",
+            "id": "E-MTAB-2805",
+            "array_express_investigation": "E-MTAB-2805",
+            "contributors": [
+                {
+                    "core": {
+                        "type": "contact",
+                        "schema_version": "3.0.0",
+                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/contact.json"
+                    },
+                    "name": "Kedar,N,Natarajan"
+                }
+            ],
+            "ddjb_trace": "ERP006670",
+            "description": "In this study, we aimed to study the gene expression patterns at single cell level across the different cell cycle stages in mESC. We performed single cell RNA-Seq experiment on mESC that were stained with Hoechst 33342 and Flow cytometry sorted for G1, S and G2M stages of cell cycle. Single cell RNA-Seq was performed using Fluidigm C1 system and libraries were generated using Nextera XT (Illumina) kit.",
+            "experimental_design": [
+                {
+                    "text": "cell type comparison design"
+                },
+                {
+                    "text": "in_vitro_design"
+                },
+                {
+                    "text": "co-expression_design"
+                }
+            ],
+            "experimental_factor_name": [
+                "cell cycle stage"
+            ],
+            "publications": [
+                {
+                    "core": {
+                        "type": "publication",
+                        "schema_version": "3.0.0",
+                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/publication.json"
+                    },
+                    "authors": [
+                        "Natarajan, K"
+                    ]
+                }
+            ],
+            "submitter": {
+                "core": {
+                    "type": "contact",
+                    "schema_version": "3.0.0",
+                    "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/contact.json"
+                },
+                "city": "Hinxton",
+                "country": "UK",
+                "email": "kedarnat@ebi.ac.uk",
+                "institution": "EMBL-EBI, Wellcome Trust Genome Campus, Cambridge",
+                "name": "Kedar,N,Natarajan"
+            },
+            "supplementary_files": [
+                "ERCC_Sequences.txt"
+            ],
+            "protocols": [
+                {
+                    "core": {
+                        "type": "protocol",
+                        "schema_version": "3.0.0",
+                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/protocol.json"
+                    },
+                    "description": "mESC were grown in standard 2i media. The media composition was N2B27 basal media (NDiff 227, StemCells), 100 U/ml recombinant human leukemia inhibitory factor (Millipore), 1M PD0325901 (Stemgent), 3M CHIR99021 (Stemgent).",
+                    "type": {
+                        "text": "growth protocol"
+                    },
+                    "id": "e9fa2f85-5958-4db1-93e2-f8a6b4f066ca"
+                },
+                {
+                    "core": {
+                        "type": "protocol",
+                        "schema_version": "3.0.0",
+                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/protocol.json"
+                    },
+                    "description": "Sorted cells corresponding to cycle fractions (G1, S and G2M) were collected and loaded on the 10-17 micron Fluidigm C1 Single-Cell Auto Prep IFC.",
+                    "type": {
+                        "text": "sample collection protocol"
+                    },
+                    "id": "427c4ca2-c4ec-45ce-9bfb-aa753ae5594f"
+                },
+                {
+                    "core": {
+                        "type": "protocol",
+                        "schema_version": "3.0.0",
+                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/protocol.json"
+                    },
+                    "description": "For sorting of cell cycle fractions (G1, S and G2M), cells were trypisinized and stained with Hoechst 33342 (5_M) for 30min at 37C. Cells were sorted based on Hoechst staining for G1, S and G2M stages of cell cycle.",
+                    "type": {
+                        "text": "treatment protocol"
+                    },
+                    "id": "80427428-5260-4acd-aed8-fdf3e393a034"
+                },
+                {
+                    "core": {
+                        "type": "protocol",
+                        "schema_version": "3.0.0",
+                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/protocol.json"
+                    },
+                    "description": "For each cell cycle fraction, 3000 cells were loaded onto a 10-17 micron Fluidigm C1 Single-Cell Auto Prep IFC and cell capture was performed as per manufacturers protocol. Single cell capture, lysis, Reverse transcription and cDNA amplification are performed using the SMARTer cDNA synthesis kit (Clonetech) and Advantage2PCR kit (Clonetech) with 1:100 ratio of spike in (Ambion), within the IFC inside the C1-Autoprep system as per manufacturers protocol.",
+                    "type": {
+                        "text": "nucleic acid extraction protocol"
+                    },
+                    "id": "55d09648-6607-4302-bc06-b8cd9e7630a1"
+                },
+                {
+                    "core": {
+                        "type": "protocol",
+                        "schema_version": "3.0.0",
+                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/protocol.json"
+                    },
+                    "description": "Harvested cDNA from single cells after C1-Autoprep system run were used to make single cell libraries using Nextera XT DNA sample preparation kit (Illumina) utilising 96 dual barcoded indices. Library poolup was performed using AMPure XP beads (Agencourt Biosciences) and single cell libraries were sent for paired end sequencing at the Wellcome Trust Sequencing facility",
+                    "type": {
+                        "text": "nucleic acid library construction protocol"
+                    },
+                    "id": "b19fe364-75da-4136-9eaf-9af7426efa5d"
+                },
+                {
+                    "core": {
+                        "type": "protocol",
+                        "schema_version": "3.0.0",
+                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/protocol.json"
+                    },
+                    "description": "Single cell libraries were multiplexed and sequenced across 4 lanes of HiSeq 2000 (Illumina) using 100bp paired-end sequencing.",
+                    "type": {
+                        "text": "nucleic acid sequencing protocol"
+                    },
+                    "id": "6d2db841-811a-48bf-9638-5889b830daa7"
+                },
+                {
+                    "core": {
+                        "type": "protocol",
+                        "schema_version": "3.0.0",
+                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/protocol.json"
+                    },
+                    "description": "As per Wellcome Trust Sequencing pipeline guidelines",
+                    "type": {
+                        "text": "high throughput sequence alignment protocol"
+                    },
+                    "id": "48743d35-375b-4211-abb7-07ccde5e90a4"
+                },
+                {
+                    "core": {
+                        "type": "protocol",
+                        "schema_version": "3.0.0",
+                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/protocol.json"
+                    },
+                    "description": "Mapping for each single cell dataset was done using GSNAP/GMAP (released on 2014-01-21) to a custom mouse genome (mm10; Ensembl GRCm38.p1) including ERCC sequences. Mapped reads were counted using HTSeq (0.6.1)",
+                    "type": {
+                        "text": "normalization data transformation protocol"
+                    },
+                    "id": "322d3d98-5707-4199-914c-c99ca6ec8050"
+                },
+                {
+                    "core": {
+                        "type": "protocol",
+                        "schema_version": "3.0.0",
+                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/protocol.json"
+                    },
+                    "description": "fresh",
+                    "type": {
+                        "text": "storage protocol"
+                    },
+                    "id": "P-LOCL-9"
+                }
+            ]
+        }
+    )
+
+@app.route('/v1/files/328229b7-5a5a-43fc-84d4-c3071d6e2d57')
+def give_file_sample():
+    return jsonify(
+        {
+            "core": {
+                "type": "sample",
+                "schema_version": "3.0.0",
+                "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/sample.json"
+            },
+            "body_part": {
+                "text": "embryonic stem cell"
+            },
+            "cell_line": {
+                "core": {
+                    "type": "cell_line",
+                    "schema_version": "3.0.0",
+                    "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/cell_line.json"
+                },
+                "name": {
+                    "text": "AB2.2"
+                }
+            },
+            "culture_type": "cell line",
+            "donor": {
+                "core": {
+                    "type": "donor",
+                    "schema_version": "3.0.0",
+                    "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/donor.json"
+                },
+                "species": {
+                    "ontology": "10090",
+                    "text": "Mus musculus"
+                },
+                "is_living": "no"
+            },
+            "organ": {
+                "ontology": "UBERON_0000922",
+                "text": "embryo"
+            },
+            "preservation": {
+                "core": {
+                    "type": "preservation",
+                    "schema_version": "3.0.0",
+                    "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/preservation.json"
+                },
+                "storage_protocol": "P-LOCL-9"
+            },
+            "supplementary_files": [
+                "ftp://ftp.ebi.ac.uk/pub/databases/microarray/data/experiment/MTAB/E-MTAB-2805/E-MTAB-2805.processed.1.zip"
+            ],
+            "total_estimated_cells": 1,
+            "well": {
+                "core": {
+                    "type": "well",
+                    "schema_version": "3.0.0",
+                    "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/well.json"
+                },
+                "cell_type": {
+                    "text": "embyronic stem cell"
+                },
+                "name": "G1_cell1"
+            },
+            "protocol_ids": [
+                "e9fa2f85-5958-4db1-93e2-f8a6b4f066ca",
+                "427c4ca2-c4ec-45ce-9bfb-aa753ae5594f",
+                "80427428-5260-4acd-aed8-fdf3e393a034",
+                "55d09648-6607-4302-bc06-b8cd9e7630a1",
+                "b19fe364-75da-4136-9eaf-9af7426efa5d",
+                "6d2db841-811a-48bf-9638-5889b830daa7",
+                "48743d35-375b-4211-abb7-07ccde5e90a4",
+                "322d3d98-5707-4199-914c-c99ca6ec8050"
+            ],
+            "project_id": "E-MTAB-2805",
+            "cell_cycle": {
+                "text": "G1 phase"
+            },
+            "name": "G1 phase mESCs",
+            "title": "G1 phase mouse embryonic stem cell line AB2.2",
+            "id": "d3abdd56-8d52-44d9-938b-f349e827e06e",
+            "ena_sample": "ERS527385",
+            "submitter_id": "G1_cell1"
+        }
+    )
+
+@app.route('/v1/files/<file_uuid>')
+def give_file():
+    return give_file_assay()
+

--- a/test/test_flask.py
+++ b/test/test_flask.py
@@ -1,11 +1,14 @@
 from flask import Flask, jsonify
+
 app = Flask(__name__)
+
 
 # this is a flask mock-up of the blue box and used for testing purposes
 
 @app.route('/')
 def hello_world():
     return 'Hello, World!'
+
 
 @app.route('/v1/bundles/<bundle_uuid>')
 def give_bundle(bundle_uuid):
@@ -15,59 +18,69 @@ def give_bundle(bundle_uuid):
                 "creator_uid": 1,
                 "files": [
                     {
-                        "content-type": "application/json",
-                        "crc32c": "bb52aea3",
-                        "indexed": True,
                         "name": "assay.json",
-                        "s3_etag": "345f3c5065d77925d2aceff03de276b3",
-                        "sha1": "b7132ca4a56bcee6469266f6ef612c3b3bbbc52c",
-                        "sha256": "3d7d562856984cb1d8d378618baaa94b3cc44988b899d2838018bf947b8d7cb8",
                         "uuid": "c1fb1206-7c6a-408c-b056-91eedb3f7a19",
-                        "version": "2017-09-22T001550.273020Z"
+                        "version": "2017-09-22T001550.273020Z",
+                        "content-type": "application/json",
+                        "indexed": True,
+                        "crc32c": "bb52aea3",
+                        "s3-etag": "345f3c5065d77925d2aceff03de276b3",
+                        "sha1": "b7132ca4a56bcee6469266f6ef612c3b3bbbc52c",
+                        "sha256": "3d7d562856984cb1d8d378618baaa94b3cc44988b89"
+                                  "9d2838018bf947b8d7cb8",
+                        "size": 1137
                     },
                     {
-                        "content-type": "gzip",
-                        "crc32c": "e68855a7",
-                        "indexed": True,
                         "name": "ERR580157_1.fastq.gz",
-                        "s3_etag": "e771bab4b85e09b9a714f53b2fca366f",
-                        "sha1": "99c3ea974678720f1159fe61f77d958bb533bd7d",
-                        "sha256": "c4d20c2d5e6d8276f96d7a9dc4a8df1650a2b34d70d0f775f35a174035fa4141",
                         "uuid": "52d4f049-2c9a-4a75-8dd4-9559902e67bd",
-                        "version": "2017-09-22T001551.542119Z"
-                    },
-                    {
+                        "version": "2017-09-22T001551.542119Z",
                         "content-type": "gzip",
-                        "crc32c": "ee751fc7",
                         "indexed": True,
+                        "crc32c": "e68855a7",
+                        "s3-etag": "e771bab4b85e09b9a714f53b2fca366f",
+                        "sha1": "99c3ea974678720f1159fe61f77d958bb533bd7d",
+                        "sha256": "c4d20c2d5e6d8276f96d7a9dc4a8df1650a2b34d70d"
+                                  "0f775f35a174035fa4141",
+                        "size": 11
+                    },
+                    {
                         "name": "ERR580157_2.fastq.gz",
-                        "s3_etag": "15d80faa6b78463c2bd9e8789b0a3d25",
-                        "sha1": "b143f054b564c31f72f51b66d28bb922a0c0317d",
-                        "sha256": "91f33631ff0b30c0cd1e06489436a0e6944eec205338f10bf979b179b3fbb919",
                         "uuid": "cd6c128b-cf1f-49dc-b3d8-1eb39115f90e",
-                        "version": "2017-09-22T001552.608139Z"
+                        "version": "2017-09-22T001552.608139Z",
+                        "content-type": "gzip",
+                        "indexed": True,
+                        "crc32c": "ee751fc7",
+                        "s3-etag": "15d80faa6b78463c2bd9e8789b0a3d25",
+                        "sha1": "b143f054b564c31f72f51b66d28bb922a0c0317d",
+                        "sha256": "91f33631ff0b30c0cd1e06489436a0e6944eec20533"
+                                  "8f10bf979b179b3fbb919",
+                        "size": 12
                     },
                     {
-                        "content-type": "application/json",
-                        "crc32c": "c155a99c",
-                        "indexed": True,
                         "name": "project.json",
-                        "s3_etag": "0cefbf7e03412a031ece2e337716eb49",
-                        "sha1": "ff010c9c38c6db711c8534db11587a98a95ef5cf",
-                        "sha256": "fc13c24cd7b9c3f3bb378f874c81573a5edb617078c6c1ab533fc9724d5c57ee",
                         "uuid": "d1bf1d60-7aaf-44c4-b8be-52180ac98535",
-                        "version": "2017-09-22T001553.697403Z"
+                        "version": "2017-09-22T001553.697403Z",
+                        "content-type": "application/json",
+                        "indexed": True,
+                        "crc32c": "c155a99c",
+                        "s3-etag": "0cefbf7e03412a031ece2e337716eb49",
+                        "sha1": "ff010c9c38c6db711c8534db11587a98a95ef5cf",
+                        "sha256": "fc13c24cd7b9c3f3bb378f874c81573a5edb617078c"
+                                  "6c1ab533fc9724d5c57ee",
+                        "size": 5487
                     },
                     {
-                        "content-type": "application/json",
-                        "crc32c": "91bb5ad5",
-                        "indexed": True,
                         "name": "sample.json",
-                        "s3_etag": "6778129b17287d80d2bd85695cdf5bd0",
-                        "sha1": "0af94780add752c632f6e8531b6c661d8eec5ef0",
-                        "sha256": "6135e1f93b8b6536f4893c31419d2640b0fd0d1eea927b5e1c8690739f00646e",
                         "uuid": "328229b7-5a5a-43fc-84d4-c3071d6e2d57",
-                        "version": "2017-09-22T001554.790410Z"
+                        "version": "2017-09-22T001554.790410Z",
+                        "content-type": "application/json",
+                        "indexed": True,
+                        "crc32c": "91bb5ad5",
+                        "s3-etag": "6778129b17287d80d2bd85695cdf5bd0",
+                        "sha1": "0af94780add752c632f6e8531b6c661d8eec5ef0",
+                        "sha256": "6135e1f93b8b6536f4893c31419d2640b0fd0d1eea9"
+                                  "27b5e1c8690739f00646e",
+                        "size": 1700
                     }
                 ],
                 "uuid": "b1db2bf9-855a-4961-ae39-be2a8d6aa864",
@@ -84,13 +97,15 @@ def give_file_assay():
             "core": {
                 "type": "assay",
                 "schema_version": "3.0.0",
-                "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/assay.json"
+                "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/"
+                              "schema/assay.json"
             },
             "rna": {
                 "core": {
                     "type": "rna",
                     "schema_version": "3.0.0",
-                    "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/rna.json"
+                    "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/"
+                                  "schema/rna.json"
                 },
                 "end_bias": "full_transcript",
                 "primer": "random",
@@ -101,7 +116,8 @@ def give_file_assay():
                 "core": {
                     "type": "seq",
                     "schema_version": "3.0.0",
-                    "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/seq.json"
+                    "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/"
+                                  "schema/seq.json"
                 },
                 "instrument_model": "Illumina HiSeq 2000",
                 "instrument_platform": "Illumina",
@@ -111,8 +127,10 @@ def give_file_assay():
                 "lanes": [
                     {
                         "number": 1,
-                        "r1": "ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR580/ERR580157/ERR580157_1.fastq.gz",
-                        "r2": "ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR580/ERR580157/ERR580157_2.fastq.gz"
+                        "r1": "ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR580/"
+                              "ERR580157/ERR580157_1.fastq.gz",
+                        "r2": "ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR580/"
+                              "ERR580157/ERR580157_2.fastq.gz"
                     }
                 ],
                 "ena_experiment": "ERX538284",
@@ -122,7 +140,8 @@ def give_file_assay():
                 "core": {
                     "type": "single_cell",
                     "schema_version": "3.0.0",
-                    "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/single_cell.json"
+                    "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/"
+                                  "schema/single_cell.json"
                 },
                 "cell_handling": "Fluidigm C1"
             },
@@ -131,6 +150,7 @@ def give_file_assay():
         }
     )
 
+
 @app.route('/v1/files/d1bf1d60-7aaf-44c4-b8be-52180ac98535')
 def give_file_project():
     return jsonify(
@@ -138,9 +158,11 @@ def give_file_project():
             "core": {
                 "type": "project",
                 "schema_version": "3.0.0",
-                "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/project.json"
+                "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/"
+                              "schema/project.json"
             },
-            "title": "Gene expression pattern of single mES cells during cell cycle stages",
+            "title": "Gene expression pattern of single mES cells during "
+                     "cell cycle stages",
             "id": "E-MTAB-2805",
             "array_express_investigation": "E-MTAB-2805",
             "contributors": [
@@ -148,13 +170,22 @@ def give_file_project():
                     "core": {
                         "type": "contact",
                         "schema_version": "3.0.0",
-                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/contact.json"
+                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/"
+                                      "schema/contact.json"
                     },
                     "name": "Kedar,N,Natarajan"
                 }
             ],
             "ddjb_trace": "ERP006670",
-            "description": "In this study, we aimed to study the gene expression patterns at single cell level across the different cell cycle stages in mESC. We performed single cell RNA-Seq experiment on mESC that were stained with Hoechst 33342 and Flow cytometry sorted for G1, S and G2M stages of cell cycle. Single cell RNA-Seq was performed using Fluidigm C1 system and libraries were generated using Nextera XT (Illumina) kit.",
+            "description": "In this study, we aimed to study the gene "
+                           "expression patterns at single cell level across "
+                           "the different cell cycle stages in mESC. "
+                           "We performed single cell RNA-Seq experiment on "
+                           "mESC that were stained with Hoechst 33342 and "
+                           "Flow cytometry sorted for G1, S and G2M stages of "
+                           "cell cycle. Single cell RNA-Seq was performed "
+                           "using Fluidigm C1 system and libraries were "
+                           "generated using Nextera XT (Illumina) kit.",
             "experimental_design": [
                 {
                     "text": "cell type comparison design"
@@ -174,7 +205,8 @@ def give_file_project():
                     "core": {
                         "type": "publication",
                         "schema_version": "3.0.0",
-                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/publication.json"
+                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/"
+                                      "schema/publication.json"
                     },
                     "authors": [
                         "Natarajan, K"
@@ -185,12 +217,14 @@ def give_file_project():
                 "core": {
                     "type": "contact",
                     "schema_version": "3.0.0",
-                    "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/contact.json"
+                    "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/"
+                                  "schema/contact.json"
                 },
                 "city": "Hinxton",
                 "country": "UK",
                 "email": "kedarnat@ebi.ac.uk",
-                "institution": "EMBL-EBI, Wellcome Trust Genome Campus, Cambridge",
+                "institution": "EMBL-EBI, Wellcome Trust Genome Campus, "
+                               "Cambridge",
                 "name": "Kedar,N,Natarajan"
             },
             "supplementary_files": [
@@ -201,9 +235,15 @@ def give_file_project():
                     "core": {
                         "type": "protocol",
                         "schema_version": "3.0.0",
-                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/protocol.json"
+                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/"
+                                      "schema/protocol.json"
                     },
-                    "description": "mESC were grown in standard 2i media. The media composition was N2B27 basal media (NDiff 227, StemCells), 100 U/ml recombinant human leukemia inhibitory factor (Millipore), 1M PD0325901 (Stemgent), 3M CHIR99021 (Stemgent).",
+                    "description": "mESC were grown in standard 2i media. "
+                                   "The media composition was N2B27 basal "
+                                   "media (NDiff 227, StemCells), 100 U/ml "
+                                   "recombinant human leukemia inhibitory "
+                                   "factor (Millipore), 1M PD0325901 "
+                                   "(Stemgent), 3M CHIR99021 (Stemgent).",
                     "type": {
                         "text": "growth protocol"
                     },
@@ -213,9 +253,13 @@ def give_file_project():
                     "core": {
                         "type": "protocol",
                         "schema_version": "3.0.0",
-                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/protocol.json"
+                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/"
+                                      "schema/protocol.json"
                     },
-                    "description": "Sorted cells corresponding to cycle fractions (G1, S and G2M) were collected and loaded on the 10-17 micron Fluidigm C1 Single-Cell Auto Prep IFC.",
+                    "description": "Sorted cells corresponding to cycle "
+                                   "fractions (G1, S and G2M) were collected "
+                                   "and loaded on the 10-17 micron Fluidigm "
+                                   "C1 Single-Cell Auto Prep IFC.",
                     "type": {
                         "text": "sample collection protocol"
                     },
@@ -225,9 +269,15 @@ def give_file_project():
                     "core": {
                         "type": "protocol",
                         "schema_version": "3.0.0",
-                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/protocol.json"
+                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/"
+                                      "schema/protocol.json"
                     },
-                    "description": "For sorting of cell cycle fractions (G1, S and G2M), cells were trypisinized and stained with Hoechst 33342 (5_M) for 30min at 37C. Cells were sorted based on Hoechst staining for G1, S and G2M stages of cell cycle.",
+                    "description": "For sorting of cell cycle fractions "
+                                   "(G1, S and G2M), cells were trypisinized "
+                                   "and stained with Hoechst 33342 (5_M) for "
+                                   "30min at 37C. Cells were sorted based on "
+                                   "Hoechst staining for G1, S and G2M stages "
+                                   "of cell cycle.",
                     "type": {
                         "text": "treatment protocol"
                     },
@@ -237,9 +287,21 @@ def give_file_project():
                     "core": {
                         "type": "protocol",
                         "schema_version": "3.0.0",
-                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/protocol.json"
+                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/"
+                                      "schema/protocol.json"
                     },
-                    "description": "For each cell cycle fraction, 3000 cells were loaded onto a 10-17 micron Fluidigm C1 Single-Cell Auto Prep IFC and cell capture was performed as per manufacturers protocol. Single cell capture, lysis, Reverse transcription and cDNA amplification are performed using the SMARTer cDNA synthesis kit (Clonetech) and Advantage2PCR kit (Clonetech) with 1:100 ratio of spike in (Ambion), within the IFC inside the C1-Autoprep system as per manufacturers protocol.",
+                    "description": "For each cell cycle fraction, 3000 cells "
+                                   "were loaded onto a 10-17 micron Fluidigm "
+                                   "C1 Single-Cell Auto Prep IFC and cell "
+                                   "capture was performed as per "
+                                   "manufacturers protocol. Single cell "
+                                   "capture, lysis, Reverse transcription and "
+                                   "cDNA amplification are performed using "
+                                   "the SMARTer cDNA synthesis kit (Clonetech)"
+                                   " and Advantage2PCR kit (Clonetech) with "
+                                   "1:100 ratio of spike in (Ambion), within "
+                                   "the IFC inside the C1-Autoprep system as "
+                                   "per manufacturers protocol.",
                     "type": {
                         "text": "nucleic acid extraction protocol"
                     },
@@ -249,9 +311,19 @@ def give_file_project():
                     "core": {
                         "type": "protocol",
                         "schema_version": "3.0.0",
-                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/protocol.json"
+                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/"
+                                      "schema/protocol.json"
                     },
-                    "description": "Harvested cDNA from single cells after C1-Autoprep system run were used to make single cell libraries using Nextera XT DNA sample preparation kit (Illumina) utilising 96 dual barcoded indices. Library poolup was performed using AMPure XP beads (Agencourt Biosciences) and single cell libraries were sent for paired end sequencing at the Wellcome Trust Sequencing facility",
+                    "description": "Harvested cDNA from single cells after "
+                                   "C1-Autoprep system run were used to make "
+                                   "single cell libraries using Nextera XT "
+                                   "DNA sample preparation kit (Illumina) "
+                                   "utilising 96 dual barcoded indices. "
+                                   "Library poolup was performed using AMPure "
+                                   "XP beads (Agencourt Biosciences) and "
+                                   "single cell libraries were sent for "
+                                   "paired end sequencing at the Wellcome "
+                                   "Trust Sequencing facility",
                     "type": {
                         "text": "nucleic acid library construction protocol"
                     },
@@ -261,9 +333,13 @@ def give_file_project():
                     "core": {
                         "type": "protocol",
                         "schema_version": "3.0.0",
-                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/protocol.json"
+                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/"
+                                      "schema/protocol.json"
                     },
-                    "description": "Single cell libraries were multiplexed and sequenced across 4 lanes of HiSeq 2000 (Illumina) using 100bp paired-end sequencing.",
+                    "description": "Single cell libraries were multiplexed "
+                                   "and sequenced across 4 lanes of HiSeq "
+                                   "2000 (Illumina) using 100bp "
+                                   "paired-end sequencing.",
                     "type": {
                         "text": "nucleic acid sequencing protocol"
                     },
@@ -273,9 +349,11 @@ def give_file_project():
                     "core": {
                         "type": "protocol",
                         "schema_version": "3.0.0",
-                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/protocol.json"
+                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/"
+                                      "schema/protocol.json"
                     },
-                    "description": "As per Wellcome Trust Sequencing pipeline guidelines",
+                    "description": "As per Wellcome Trust Sequencing "
+                                   "pipeline guidelines",
                     "type": {
                         "text": "high throughput sequence alignment protocol"
                     },
@@ -285,9 +363,15 @@ def give_file_project():
                     "core": {
                         "type": "protocol",
                         "schema_version": "3.0.0",
-                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/protocol.json"
+                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/"
+                                      "schema/protocol.json"
                     },
-                    "description": "Mapping for each single cell dataset was done using GSNAP/GMAP (released on 2014-01-21) to a custom mouse genome (mm10; Ensembl GRCm38.p1) including ERCC sequences. Mapped reads were counted using HTSeq (0.6.1)",
+                    "description": "Mapping for each single cell dataset was "
+                                   "done using GSNAP/GMAP "
+                                   "(released on 2014-01-21) to a custom "
+                                   "mouse genome (mm10; Ensembl GRCm38.p1) "
+                                   "including ERCC sequences. Mapped reads "
+                                   "were counted using HTSeq (0.6.1)",
                     "type": {
                         "text": "normalization data transformation protocol"
                     },
@@ -297,7 +381,8 @@ def give_file_project():
                     "core": {
                         "type": "protocol",
                         "schema_version": "3.0.0",
-                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/protocol.json"
+                        "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/"
+                                      "schema/protocol.json"
                     },
                     "description": "fresh",
                     "type": {
@@ -309,6 +394,7 @@ def give_file_project():
         }
     )
 
+
 @app.route('/v1/files/328229b7-5a5a-43fc-84d4-c3071d6e2d57')
 def give_file_sample():
     return jsonify(
@@ -316,7 +402,8 @@ def give_file_sample():
             "core": {
                 "type": "sample",
                 "schema_version": "3.0.0",
-                "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/sample.json"
+                "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/"
+                              "schema/sample.json"
             },
             "body_part": {
                 "text": "embryonic stem cell"
@@ -325,7 +412,8 @@ def give_file_sample():
                 "core": {
                     "type": "cell_line",
                     "schema_version": "3.0.0",
-                    "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/cell_line.json"
+                    "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/"
+                                  "schema/cell_line.json"
                 },
                 "name": {
                     "text": "AB2.2"
@@ -336,7 +424,8 @@ def give_file_sample():
                 "core": {
                     "type": "donor",
                     "schema_version": "3.0.0",
-                    "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/donor.json"
+                    "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/"
+                                  "schema/donor.json"
                 },
                 "species": {
                     "ontology": "10090",
@@ -352,19 +441,22 @@ def give_file_sample():
                 "core": {
                     "type": "preservation",
                     "schema_version": "3.0.0",
-                    "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/preservation.json"
+                    "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/"
+                                  "schema/preservation.json"
                 },
                 "storage_protocol": "P-LOCL-9"
             },
             "supplementary_files": [
-                "ftp://ftp.ebi.ac.uk/pub/databases/microarray/data/experiment/MTAB/E-MTAB-2805/E-MTAB-2805.processed.1.zip"
+                "ftp://ftp.ebi.ac.uk/pub/databases/microarray/data/"
+                "experiment/MTAB/E-MTAB-2805/E-MTAB-2805.processed.1.zip"
             ],
             "total_estimated_cells": 1,
             "well": {
                 "core": {
                     "type": "well",
                     "schema_version": "3.0.0",
-                    "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/well.json"
+                    "schema_url": "http://hgwdev.soe.ucsc.edu/~kent/hca/"
+                                  "schema/well.json"
                 },
                 "cell_type": {
                     "text": "embyronic stem cell"
@@ -392,6 +484,7 @@ def give_file_sample():
             "submitter_id": "G1_cell1"
         }
     )
+
 
 @app.route('/v1/files/<file_uuid>')
 def give_file():

--- a/test/test_indexer.py
+++ b/test/test_indexer.py
@@ -1,10 +1,12 @@
 import unittest
-from app import get_bundles, get_file, flatten, look_file, es_check, write_es, write_index, es, post_notification, every_day
+from app import get_bundles, get_file, flatten, look_file, es_check, \
+    write_es, write_index, es
 import json
 import os
 
 # use this file to unittest app.py
-# requirements: app.py, chalicelib/, running test_flask.py, declared env var: ES_INDEX = test-index
+# requirements: app.py, chalicelib/, running test_flask.py,
+# declared env var: ES_INDEX = test-index
 
 # bb_host = "https://"+os.environ['BLUE_BOX_ENDPOINT']
 # in_host = "https://"+os.environ['INDEXER_ENDPOINT']
@@ -13,20 +15,144 @@ es_host = os.environ['ES_ENDPOINT']
 # Input
 bundle_uuid = 'b1db2bf9-855a-4961-ae39-be2a8d6aa864'
 file_uuid = 'c1fb1206-7c6a-408c-b056-91eedb3f7a19'
-json_file = json.loads('{"core":{"type":"assay","schema_version":"3.0.0","schema_url":"http://hgwdev.soe.ucsc.edu/~kent/hca/schema/assay.json"},"rna":{"core":{"type":"rna","schema_version":"3.0.0","schema_url":"http://hgwdev.soe.ucsc.edu/~kent/hca/schema/rna.json"},"end_bias":"full_transcript","primer":"random","library_construction":"SMARTer Ultra Low RNA Kit","spike_in":"ERCC"},"seq":{"core":{"type":"seq","schema_version":"3.0.0","schema_url":"http://hgwdev.soe.ucsc.edu/~kent/hca/schema/seq.json"},"instrument_model":"Illumina HiSeq 2000","instrument_platform":"Illumina","library_construction":"Nextera XT","molecule":"RNA","paired_ends":"yes","lanes":[{"number":1,"r1":"ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR580/ERR580157/ERR580157_1.fastq.gz","r2":"ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR580/ERR580157/ERR580157_2.fastq.gz"}],"ena_experiment":"ERX538284","ena_run":"ERR580157"},"single_cell":{"core":{"type":"single_cell","schema_version":"3.0.0","schema_url":"http://hgwdev.soe.ucsc.edu/~kent/hca/schema/single_cell.json"},"cell_handling":"Fluidigm C1"},"sample_id":"d3abdd56-8d52-44d9-938b-f349e827e06e","id":"c8899599-4d25-416a-96bd-2c22c54a0c25"}')
+json_file = json.loads(
+    '{"core":{"type":"assay","schema_version":"3.0.0",'
+    '"schema_url":"http://hgwdev.soe.ucsc.edu/~kent/hca/schema/assay.json"},'
+    '"rna":{"core":{"type":"rna","schema_version":"3.0.0",'
+    '"schema_url":"http://hgwdev.soe.ucsc.edu/~kent/hca/schema/rna.json"},'
+    '"end_bias":"full_transcript","primer":"random",'
+    '"library_construction":"SMARTer Ultra Low RNA Kit","spike_in":"ERCC"},'
+    '"seq":{"core":{"type":"seq","schema_version":"3.0.0",'
+    '"schema_url":"http://hgwdev.soe.ucsc.edu/~kent/hca/schema/seq.json"},'
+    '"instrument_model":"Illumina HiSeq 2000",'
+    '"instrument_platform":"Illumina",'
+    '"library_construction":"Nextera XT","molecule":"RNA","paired_ends":"yes",'
+    '"lanes":[{"number":1,"r1":"ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR580/'
+    'ERR580157/ERR580157_1.fastq.gz",'
+    '"r2":"ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR580/ERR580157/'
+    'ERR580157_2.fastq.gz"}],"ena_experiment":"ERX538284",'
+    '"ena_run":"ERR580157"},"single_cell":{"core":{"type":"single_cell",'
+    '"schema_version":"3.0.0","schema_url":"http://hgwdev.soe.ucsc.edu/~kent/'
+    'hca/schema/single_cell.json"},"cell_handling":"Fluidigm C1"},'
+    '"sample_id":"d3abdd56-8d52-44d9-938b-f349e827e06e",'
+    '"id":"c8899599-4d25-416a-96bd-2c22c54a0c25"}')
 c_item1 = 'id*text_autocomplete*keyword'
 c_item2 = {"rna": {"primer": "random*keyword*text", "spike_in": "ERCC"}}
-to_flatten = [1,[2],[3,[4],[5, [6]],7], 8]
-
+to_flatten = [1, [2], [3, [4], [5, [6]], 7], 8]
 
 # Expected Output
-expected_bundle = '{"json_files":[{"assay.json":"c1fb1206-7c6a-408c-b056-91eedb3f7a19"},{"project.json":"d1bf1d60-7aaf-44c4-b8be-52180ac98535"},{"sample.json":"328229b7-5a5a-43fc-84d4-c3071d6e2d57"}],"data_files":[{"ERR580157_1.fastq.gz":{"content-type":"gzip","crc32c":"e68855a7","indexed":true,"name":"ERR580157_1.fastq.gz","s3_etag":"e771bab4b85e09b9a714f53b2fca366f","sha1":"99c3ea974678720f1159fe61f77d958bb533bd7d","sha256":"c4d20c2d5e6d8276f96d7a9dc4a8df1650a2b34d70d0f775f35a174035fa4141","uuid":"52d4f049-2c9a-4a75-8dd4-9559902e67bd","version":"2017-09-22T001551.542119Z"}},{"ERR580157_2.fastq.gz":{"content-type":"gzip","crc32c":"ee751fc7","indexed":true,"name":"ERR580157_2.fastq.gz","s3_etag":"15d80faa6b78463c2bd9e8789b0a3d25","sha1":"b143f054b564c31f72f51b66d28bb922a0c0317d","sha256":"91f33631ff0b30c0cd1e06489436a0e6944eec205338f10bf979b179b3fbb919","uuid":"cd6c128b-cf1f-49dc-b3d8-1eb39115f90e","version":"2017-09-22T001552.608139Z"}}]}'
-expected_file = '{"core":{"type":"assay","schema_version":"3.0.0","schema_url":"http://hgwdev.soe.ucsc.edu/~kent/hca/schema/assay.json"},"rna":{"core":{"type":"rna","schema_version":"3.0.0","schema_url":"http://hgwdev.soe.ucsc.edu/~kent/hca/schema/rna.json"},"end_bias":"full_transcript","primer":"random","library_construction":"SMARTer Ultra Low RNA Kit","spike_in":"ERCC"},"seq":{"core":{"type":"seq","schema_version":"3.0.0","schema_url":"http://hgwdev.soe.ucsc.edu/~kent/hca/schema/seq.json"},"instrument_model":"Illumina HiSeq 2000","instrument_platform":"Illumina","library_construction":"Nextera XT","molecule":"RNA","paired_ends":"yes","lanes":[{"number":1,"r1":"ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR580/ERR580157/ERR580157_1.fastq.gz","r2":"ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR580/ERR580157/ERR580157_2.fastq.gz"}],"ena_experiment":"ERX538284","ena_run":"ERR580157"},"single_cell":{"core":{"type":"single_cell","schema_version":"3.0.0","schema_url":"http://hgwdev.soe.ucsc.edu/~kent/hca/schema/single_cell.json"},"cell_handling":"Fluidigm C1"},"sample_id":"d3abdd56-8d52-44d9-938b-f349e827e06e","id":"c8899599-4d25-416a-96bd-2c22c54a0c25"}'
+expected_bundle = '{"json_files": ' \
+                  '[{"assay.json": ' \
+                  '"c1fb1206-7c6a-408c-b056-91eedb3f7a19"},{"project.json": ' \
+                  '"d1bf1d60-7aaf-44c4-b8be-52180ac98535"}, ' \
+                  '{"sample.json": ' \
+                  '"328229b7-5a5a-43fc-84d4-c3071d6e2d57"}], "data_files": ' \
+                  '[{"ERR580157_1.fastq.gz": {"content-type": "gzip", ' \
+                  '"crc32c": "e68855a7", "indexed": true, ' \
+                  '"name": "ERR580157_1.fastq.gz", "s3-etag": ' \
+                  '"e771bab4b85e09b9a714f53b2fca366f", "sha1": ' \
+                  '"99c3ea974678720f1159fe61f77d958bb533bd7d", "sha256": ' \
+                  '"c4d20c2d5e6d8276f96d7a9dc4a8df1650a2b34d70d0f775f35a174' \
+                  '035fa4141", "size": 11, "uuid": ' \
+                  '"52d4f049-2c9a-4a75-8dd4-9559902e67bd", "version": ' \
+                  '"2017-09-22T001551.542119Z"}}, {"ERR580157_2.fastq.gz": ' \
+                  '{"content-type": "gzip", "crc32c": "ee751fc7", ' \
+                  '"indexed": true, "name": "ERR580157_2.fastq.gz", ' \
+                  '"s3-etag": "15d80faa6b78463c2bd9e8789b0a3d25", ' \
+                  '"sha1": "b143f054b564c31f72f51b66d28bb922a0c0317d", ' \
+                  '"sha256": "91f33631ff0b30c0cd1e06489436a0e6944eec205338f1' \
+                  '0bf979b179b3fbb919", "size": 12, ' \
+                  '"uuid": "cd6c128b-cf1f-49dc-b3d8-1eb39115f90e", ' \
+                  '"version": "2017-09-22T001552.608139Z"}}]}'
+expected_file = '{"core":{"type":"assay","schema_version":"3.0.0",' \
+                '"schema_url":"http://hgwdev.soe.ucsc.edu/~kent/hca/schema' \
+                '/assay.json"},"rna":{"core":{"type":"rna",' \
+                '"schema_version":"3.0.0","schema_url":' \
+                '"http://hgwdev.soe.ucsc.edu/~kent/hca/schema/rna.json"},' \
+                '"end_bias":"full_transcript","primer":"random",' \
+                '"library_construction":"SMARTer Ultra Low RNA Kit",' \
+                '"spike_in":"ERCC"},"seq":{"core":{"type":"seq",' \
+                '"schema_version":"3.0.0",' \
+                '"schema_url":"http://hgwdev.soe.ucsc.edu/~kent/hca/schema' \
+                '/seq.json"},"instrument_model":"Illumina HiSeq 2000",' \
+                '"instrument_platform":"Illumina",' \
+                '"library_construction":"Nextera XT","molecule":"RNA",' \
+                '"paired_ends":"yes",' \
+                '"lanes":[{"number":1,"r1":"ftp://ftp.sra.ebi.ac.uk/vol1/' \
+                'fastq/ERR580/ERR580157/ERR580157_1.fastq.gz",' \
+                '"r2":"ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR580/ERR580157/' \
+                'ERR580157_2.fastq.gz"}],"ena_experiment":"ERX538284",' \
+                '"ena_run":"ERR580157"},"single_cell":{"core":' \
+                '{"type":"single_cell","schema_version":"3.0.0",' \
+                '"schema_url":"http://hgwdev.soe.ucsc.edu/~kent/hca/schema/' \
+                'single_cell.json"},"cell_handling":"Fluidigm C1"},' \
+                '"sample_id":"d3abdd56-8d52-44d9-938b-f349e827e06e",' \
+                '"id":"c8899599-4d25-416a-96bd-2c22c54a0c25"}'
 expected_look1 = json.loads('{"id": "c8899599-4d25-416a-96bd-2c22c54a0c25"}')
 expected_look2 = [{'rna|primer': 'random'}, {'rna|spike_in': 'ERCC'}]
 expected_flatten = [1, 2, 3, 4, 5, 6, 7, 8]
 expected_es = "You Know, for Search"
-expected_index =[{"assay,json|single_cell|cell_handling":"Fluidigm C1","assay,json|rna|library_construction":"SMARTer Ultra Low RNA Kit","assay,json|rna|spike_in":"ERCC","assay,json|seq|paired_ends":"yes","assay,json|seq|instrument_platform":"Illumina","assay,json|seq|library_construction":"Nextera XT","project,json|id":"E-MTAB-2805","project,json|submitter|name":"Kedar,N,Natarajan","project,json|submitter|institution":"EMBL-EBI, Wellcome Trust Genome Campus, Cambridge","project,json|submitter|country":"UK","sample,json|body_part|text":"embryonic stem cell","sample,json|donor|species|text":"Mus musculus","sample,json|donor|species|ontology":"10090","sample,json|donor|is_living":"no","sample,json|donor|core|uuid":"None","sample,json|name":"G1 phase mESCs","sample,json|organ|text":"embryo","sample,json|project_id":"E-MTAB-2805","sample,json|cell_cycle|text":"G1 phase","sample,json|culture_type":"cell line","sample,json|donor_id":"None","bundle_uuid":"b1db2bf9-855a-4961-ae39-be2a8d6aa864","file_name":"ERR580157_1.fastq.gz","file_uuid":"52d4f049-2c9a-4a75-8dd4-9559902e67bd","file_version":"2017-09-22T001551.542119Z","file_format":"fastq.gz","bundle_type":"scRNA-Seq Upload","file_size":500000,"analysis,json|computational_method":"None"},{"assay,json|single_cell|cell_handling":"Fluidigm C1","assay,json|rna|library_construction":"SMARTer Ultra Low RNA Kit","assay,json|rna|spike_in":"ERCC","assay,json|seq|paired_ends":"yes","assay,json|seq|instrument_platform":"Illumina","assay,json|seq|library_construction":"Nextera XT","project,json|id":"E-MTAB-2805","project,json|submitter|name":"Kedar,N,Natarajan","project,json|submitter|institution":"EMBL-EBI, Wellcome Trust Genome Campus, Cambridge","project,json|submitter|country":"UK","sample,json|body_part|text":"embryonic stem cell","sample,json|donor|species|text":"Mus musculus","sample,json|donor|species|ontology":"10090","sample,json|donor|is_living":"no","sample,json|donor|core|uuid":"None","sample,json|name":"G1 phase mESCs","sample,json|organ|text":"embryo","sample,json|project_id":"E-MTAB-2805","sample,json|cell_cycle|text":"G1 phase","sample,json|culture_type":"cell line","sample,json|donor_id":"None","bundle_uuid":"b1db2bf9-855a-4961-ae39-be2a8d6aa864","file_name":"ERR580157_2.fastq.gz","file_uuid":"cd6c128b-cf1f-49dc-b3d8-1eb39115f90e","file_version":"2017-09-22T001552.608139Z","file_format":"fastq.gz","bundle_type":"scRNA-Seq Upload","file_size":500000,"analysis,json|computational_method":"None"}]
+expected_index = [{"assay,json|single_cell|cell_handling": "Fluidigm C1",
+                   "assay,json|rna|library_construction":
+                       "SMARTer Ultra Low RNA Kit",
+                   "assay,json|rna|spike_in": "ERCC",
+                   "assay,json|seq|paired_ends": "yes",
+                   "assay,json|seq|instrument_platform": "Illumina",
+                   "assay,json|seq|library_construction": "Nextera XT",
+                   "project,json|id": "E-MTAB-2805",
+                   "project,json|submitter|name": "Kedar,N,Natarajan",
+                   "project,json|submitter|institution":
+                       "EMBL-EBI, Wellcome Trust Genome Campus, Cambridge",
+                   "project,json|submitter|country": "UK",
+                   "sample,json|body_part|text": "embryonic stem cell",
+                   "sample,json|donor|species|text": "Mus musculus",
+                   "sample,json|donor|species|ontology": "10090",
+                   "sample,json|donor|is_living": "no",
+                   "sample,json|donor|core|uuid": "None",
+                   "sample,json|name": "G1 phase mESCs",
+                   "sample,json|organ|text": "embryo",
+                   "sample,json|project_id": "E-MTAB-2805",
+                   "sample,json|cell_cycle|text": "G1 phase",
+                   "sample,json|culture_type": "cell line",
+                   "sample,json|donor_id": "None",
+                   "bundle_uuid": "b1db2bf9-855a-4961-ae39-be2a8d6aa864",
+                   "file_name": "ERR580157_1.fastq.gz",
+                   "file_uuid": "52d4f049-2c9a-4a75-8dd4-9559902e67bd",
+                   "file_version": "2017-09-22T001551.542119Z",
+                   "file_format": "fastq.gz",
+                   "bundle_type": "scRNA-Seq Upload", "file_size": 12,
+                   "analysis,json|computational_method": "None"},
+                  {"assay,json|single_cell|cell_handling": "Fluidigm C1",
+                   "assay,json|rna|library_construction":
+                       "SMARTer Ultra Low RNA Kit",
+                   "assay,json|rna|spike_in": "ERCC",
+                   "assay,json|seq|paired_ends": "yes",
+                   "assay,json|seq|instrument_platform": "Illumina",
+                   "assay,json|seq|library_construction": "Nextera XT",
+                   "project,json|id": "E-MTAB-2805",
+                   "project,json|submitter|name": "Kedar,N,Natarajan",
+                   "project,json|submitter|institution":
+                       "EMBL-EBI, Wellcome Trust Genome Campus, Cambridge",
+                   "project,json|submitter|country": "UK",
+                   "sample,json|body_part|text": "embryonic stem cell",
+                   "sample,json|donor|species|text": "Mus musculus",
+                   "sample,json|donor|species|ontology": "10090",
+                   "sample,json|donor|is_living": "no",
+                   "sample,json|donor|core|uuid": "None",
+                   "sample,json|name": "G1 phase mESCs",
+                   "sample,json|organ|text": "embryo",
+                   "sample,json|project_id": "E-MTAB-2805",
+                   "sample,json|cell_cycle|text": "G1 phase",
+                   "sample,json|culture_type": "cell line",
+                   "sample,json|donor_id": "None",
+                   "bundle_uuid": "b1db2bf9-855a-4961-ae39-be2a8d6aa864",
+                   "file_name": "ERR580157_2.fastq.gz",
+                   "file_uuid": "cd6c128b-cf1f-49dc-b3d8-1eb39115f90e",
+                   "file_version": "2017-09-22T001552.608139Z",
+                   "file_format": "fastq.gz",
+                   "bundle_type": "scRNA-Seq Upload", "file_size": 12,
+                   "analysis,json|computational_method": "None"}]
+
 
 class TestIndexer(unittest.TestCase):
     def test_bundles(self):
@@ -45,10 +171,10 @@ class TestIndexer(unittest.TestCase):
     def test_look(self):
         name = ""
         print(len(name))
-        #test look 1 (simple)
+        # test look 1 (simple)
         tlook = look_file(c_item1, json_file, name)
         self.assertEqual(tlook, expected_look1)
-        #test look 2 (nested)
+        # test look 2 (nested)
         tlook = look_file(c_item2, json_file, name)
         self.assertEqual(tlook, expected_look2)
 
@@ -59,33 +185,35 @@ class TestIndexer(unittest.TestCase):
 
     def test_write_es(self):
         es.indices.create(index='test-index', ignore=[400])
-        es_json =[{"test":"hello world"}]
+        es_json = [{"test": "hello world"}]
         write_es(es_json, '123')
         twrite = es.get(id='123', index='test-index')
         source = twrite['_source']
-        self.assertEqual(source, {"test":"hello world"})
-        es.delete(id='123', index='test-index',doc_type='document')
+        self.assertEqual(source, {"test": "hello world"})
+        es.delete(id='123', index='test-index', doc_type='document')
 
     def test_write_index(self):
         write_index(bundle_uuid)
-        file_ids = ['b1db2bf9-855a-4961-ae39-be2a8d6aa864:52d4f049-2c9a-4a75-8dd4-9559902e67bd:2017-09-22T001551.542119Z','b1db2bf9-855a-4961-ae39-be2a8d6aa864:cd6c128b-cf1f-49dc-b3d8-1eb39115f90e:2017-09-22T001552.608139Z']
+        file_ids = [
+            'b1db2bf9-855a-4961-ae39-be2a8d6aa864:52d4f049-2c9a-4a75-8dd4-'
+            '9559902e67bd:2017-09-22T001551.542119Z',
+            'b1db2bf9-855a-4961-ae39-be2a8d6aa864:cd6c128b-cf1f-49dc-b3d8-'
+            '1eb39115f90e:2017-09-22T001552.608139Z']
         for i in range(1, len(file_ids)):
             twrite = es.get(id=file_ids[i], index='test-index')
             source = twrite['_source']
             self.assertEqual(source, expected_index[i])
             es.delete(id=file_ids[i], index='test-index', doc_type='document')
 
-    # need to clean up code on app.py first
-    # def test_post_notification(self):
-    #     every_day()
-    #
-    #     #post_notification should be called by the following command
-    #     # curl - H "Content-Type: application/json" - X POST - d '{ "query": { "query": { "bool": { "must": [ { "match": { "files.sample_json.donor.species": "Homo sapiens" } }, { "match": { "files.assay_json.single_cell.method": "Fluidigm C1" } }, { "match": { "files.sample_json.ncbi_biosample": "SAMN04303778" } } ] } } }, "subscription_id": "ba50df7b-5a97-4e87-b9ce-c0935a817f0b", "transaction_id": "ff6b7fa3-dc79-4a79-a313-296801de76b9", "match": { "bundle_version": "2017-08-03T041453.170646Z", "bundle_uuid": "4ce8a36d-51d6-4a3c-bae7-41a63699f877" } }' https://mitlxo7p17.execute-api.us-west-2.amazonaws.com/api/
-    #     post_notification()
-    #     twrite = es.get(id='123', index='test-index')
-    #     source = twrite['_source']
-    #     self.assertEqual(source, expected_index)
-    #     es.delete(id='123', index='test-index', doc_type='document')
+            # need to clean up code on app.py first
+            # def test_post_notification(self):
+            #     every_day()
+            #
+            #     post_notification()
+            #     twrite = es.get(id='123', index='test-index')
+            #     source = twrite['_source']
+            #     self.assertEqual(source, expected_index)
+            #     es.delete(id='123', index='test-index', doc_type='document')
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_indexer.py
+++ b/test/test_indexer.py
@@ -1,0 +1,92 @@
+import unittest
+from app import get_bundles, get_file, flatten, look_file, es_check, write_es, write_index, es, post_notification, every_day
+import json
+import os
+
+# use this file to unittest app.py
+# requirements: app.py, chalicelib/, running test_flask.py, declared env var: ES_INDEX = test-index
+
+# bb_host = "https://"+os.environ['BLUE_BOX_ENDPOINT']
+# in_host = "https://"+os.environ['INDEXER_ENDPOINT']
+es_host = os.environ['ES_ENDPOINT']
+
+# Input
+bundle_uuid = 'b1db2bf9-855a-4961-ae39-be2a8d6aa864'
+file_uuid = 'c1fb1206-7c6a-408c-b056-91eedb3f7a19'
+json_file = json.loads('{"core":{"type":"assay","schema_version":"3.0.0","schema_url":"http://hgwdev.soe.ucsc.edu/~kent/hca/schema/assay.json"},"rna":{"core":{"type":"rna","schema_version":"3.0.0","schema_url":"http://hgwdev.soe.ucsc.edu/~kent/hca/schema/rna.json"},"end_bias":"full_transcript","primer":"random","library_construction":"SMARTer Ultra Low RNA Kit","spike_in":"ERCC"},"seq":{"core":{"type":"seq","schema_version":"3.0.0","schema_url":"http://hgwdev.soe.ucsc.edu/~kent/hca/schema/seq.json"},"instrument_model":"Illumina HiSeq 2000","instrument_platform":"Illumina","library_construction":"Nextera XT","molecule":"RNA","paired_ends":"yes","lanes":[{"number":1,"r1":"ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR580/ERR580157/ERR580157_1.fastq.gz","r2":"ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR580/ERR580157/ERR580157_2.fastq.gz"}],"ena_experiment":"ERX538284","ena_run":"ERR580157"},"single_cell":{"core":{"type":"single_cell","schema_version":"3.0.0","schema_url":"http://hgwdev.soe.ucsc.edu/~kent/hca/schema/single_cell.json"},"cell_handling":"Fluidigm C1"},"sample_id":"d3abdd56-8d52-44d9-938b-f349e827e06e","id":"c8899599-4d25-416a-96bd-2c22c54a0c25"}')
+c_item1 = 'id*text_autocomplete*keyword'
+c_item2 = {"rna": {"primer": "random*keyword*text", "spike_in": "ERCC"}}
+to_flatten = [1,[2],[3,[4],[5, [6]],7], 8]
+
+
+# Expected Output
+expected_bundle = '{"json_files":[{"assay.json":"c1fb1206-7c6a-408c-b056-91eedb3f7a19"},{"project.json":"d1bf1d60-7aaf-44c4-b8be-52180ac98535"},{"sample.json":"328229b7-5a5a-43fc-84d4-c3071d6e2d57"}],"data_files":[{"ERR580157_1.fastq.gz":{"content-type":"gzip","crc32c":"e68855a7","indexed":true,"name":"ERR580157_1.fastq.gz","s3_etag":"e771bab4b85e09b9a714f53b2fca366f","sha1":"99c3ea974678720f1159fe61f77d958bb533bd7d","sha256":"c4d20c2d5e6d8276f96d7a9dc4a8df1650a2b34d70d0f775f35a174035fa4141","uuid":"52d4f049-2c9a-4a75-8dd4-9559902e67bd","version":"2017-09-22T001551.542119Z"}},{"ERR580157_2.fastq.gz":{"content-type":"gzip","crc32c":"ee751fc7","indexed":true,"name":"ERR580157_2.fastq.gz","s3_etag":"15d80faa6b78463c2bd9e8789b0a3d25","sha1":"b143f054b564c31f72f51b66d28bb922a0c0317d","sha256":"91f33631ff0b30c0cd1e06489436a0e6944eec205338f10bf979b179b3fbb919","uuid":"cd6c128b-cf1f-49dc-b3d8-1eb39115f90e","version":"2017-09-22T001552.608139Z"}}]}'
+expected_file = '{"core":{"type":"assay","schema_version":"3.0.0","schema_url":"http://hgwdev.soe.ucsc.edu/~kent/hca/schema/assay.json"},"rna":{"core":{"type":"rna","schema_version":"3.0.0","schema_url":"http://hgwdev.soe.ucsc.edu/~kent/hca/schema/rna.json"},"end_bias":"full_transcript","primer":"random","library_construction":"SMARTer Ultra Low RNA Kit","spike_in":"ERCC"},"seq":{"core":{"type":"seq","schema_version":"3.0.0","schema_url":"http://hgwdev.soe.ucsc.edu/~kent/hca/schema/seq.json"},"instrument_model":"Illumina HiSeq 2000","instrument_platform":"Illumina","library_construction":"Nextera XT","molecule":"RNA","paired_ends":"yes","lanes":[{"number":1,"r1":"ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR580/ERR580157/ERR580157_1.fastq.gz","r2":"ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR580/ERR580157/ERR580157_2.fastq.gz"}],"ena_experiment":"ERX538284","ena_run":"ERR580157"},"single_cell":{"core":{"type":"single_cell","schema_version":"3.0.0","schema_url":"http://hgwdev.soe.ucsc.edu/~kent/hca/schema/single_cell.json"},"cell_handling":"Fluidigm C1"},"sample_id":"d3abdd56-8d52-44d9-938b-f349e827e06e","id":"c8899599-4d25-416a-96bd-2c22c54a0c25"}'
+expected_look1 = json.loads('{"id": "c8899599-4d25-416a-96bd-2c22c54a0c25"}')
+expected_look2 = [{'rna|primer': 'random'}, {'rna|spike_in': 'ERCC'}]
+expected_flatten = [1, 2, 3, 4, 5, 6, 7, 8]
+expected_es = "You Know, for Search"
+expected_index =[{"assay,json|single_cell|cell_handling":"Fluidigm C1","assay,json|rna|library_construction":"SMARTer Ultra Low RNA Kit","assay,json|rna|spike_in":"ERCC","assay,json|seq|paired_ends":"yes","assay,json|seq|instrument_platform":"Illumina","assay,json|seq|library_construction":"Nextera XT","project,json|id":"E-MTAB-2805","project,json|submitter|name":"Kedar,N,Natarajan","project,json|submitter|institution":"EMBL-EBI, Wellcome Trust Genome Campus, Cambridge","project,json|submitter|country":"UK","sample,json|body_part|text":"embryonic stem cell","sample,json|donor|species|text":"Mus musculus","sample,json|donor|species|ontology":"10090","sample,json|donor|is_living":"no","sample,json|donor|core|uuid":"None","sample,json|name":"G1 phase mESCs","sample,json|organ|text":"embryo","sample,json|project_id":"E-MTAB-2805","sample,json|cell_cycle|text":"G1 phase","sample,json|culture_type":"cell line","sample,json|donor_id":"None","bundle_uuid":"b1db2bf9-855a-4961-ae39-be2a8d6aa864","file_name":"ERR580157_1.fastq.gz","file_uuid":"52d4f049-2c9a-4a75-8dd4-9559902e67bd","file_version":"2017-09-22T001551.542119Z","file_format":"fastq.gz","bundle_type":"scRNA-Seq Upload","file_size":500000,"analysis,json|computational_method":"None"},{"assay,json|single_cell|cell_handling":"Fluidigm C1","assay,json|rna|library_construction":"SMARTer Ultra Low RNA Kit","assay,json|rna|spike_in":"ERCC","assay,json|seq|paired_ends":"yes","assay,json|seq|instrument_platform":"Illumina","assay,json|seq|library_construction":"Nextera XT","project,json|id":"E-MTAB-2805","project,json|submitter|name":"Kedar,N,Natarajan","project,json|submitter|institution":"EMBL-EBI, Wellcome Trust Genome Campus, Cambridge","project,json|submitter|country":"UK","sample,json|body_part|text":"embryonic stem cell","sample,json|donor|species|text":"Mus musculus","sample,json|donor|species|ontology":"10090","sample,json|donor|is_living":"no","sample,json|donor|core|uuid":"None","sample,json|name":"G1 phase mESCs","sample,json|organ|text":"embryo","sample,json|project_id":"E-MTAB-2805","sample,json|cell_cycle|text":"G1 phase","sample,json|culture_type":"cell line","sample,json|donor_id":"None","bundle_uuid":"b1db2bf9-855a-4961-ae39-be2a8d6aa864","file_name":"ERR580157_2.fastq.gz","file_uuid":"cd6c128b-cf1f-49dc-b3d8-1eb39115f90e","file_version":"2017-09-22T001552.608139Z","file_format":"fastq.gz","bundle_type":"scRNA-Seq Upload","file_size":500000,"analysis,json|computational_method":"None"}]
+
+class TestIndexer(unittest.TestCase):
+    def test_bundles(self):
+        tbundle = (str(get_bundles(bundle_uuid)))
+        self.assertEqual(json.loads(tbundle), json.loads(expected_bundle))
+
+    def test_file(self):
+        tfile = (str(get_file(file_uuid)))
+        self.assertEqual(json.loads(tfile), json.loads(expected_file))
+
+    def test_flatten(self):
+        tflatten = flatten(to_flatten)
+        lflatten = (list(tflatten))
+        self.assertEqual(lflatten, expected_flatten)
+
+    def test_look(self):
+        name = ""
+        print(len(name))
+        #test look 1 (simple)
+        tlook = look_file(c_item1, json_file, name)
+        self.assertEqual(tlook, expected_look1)
+        #test look 2 (nested)
+        tlook = look_file(c_item2, json_file, name)
+        self.assertEqual(tlook, expected_look2)
+
+    def test_es(self):
+        tes = json.loads(es_check())
+        tag = tes['tagline']
+        self.assertEqual(tag, expected_es)
+
+    def test_write_es(self):
+        es.indices.create(index='test-index', ignore=[400])
+        es_json =[{"test":"hello world"}]
+        write_es(es_json, '123')
+        twrite = es.get(id='123', index='test-index')
+        source = twrite['_source']
+        self.assertEqual(source, {"test":"hello world"})
+        es.delete(id='123', index='test-index',doc_type='document')
+
+    def test_write_index(self):
+        write_index(bundle_uuid)
+        file_ids = ['b1db2bf9-855a-4961-ae39-be2a8d6aa864:52d4f049-2c9a-4a75-8dd4-9559902e67bd:2017-09-22T001551.542119Z','b1db2bf9-855a-4961-ae39-be2a8d6aa864:cd6c128b-cf1f-49dc-b3d8-1eb39115f90e:2017-09-22T001552.608139Z']
+        for i in range(1, len(file_ids)):
+            twrite = es.get(id=file_ids[i], index='test-index')
+            source = twrite['_source']
+            self.assertEqual(source, expected_index[i])
+            es.delete(id=file_ids[i], index='test-index', doc_type='document')
+
+    # need to clean up code on app.py first
+    # def test_post_notification(self):
+    #     every_day()
+    #
+    #     #post_notification should be called by the following command
+    #     # curl - H "Content-Type: application/json" - X POST - d '{ "query": { "query": { "bool": { "must": [ { "match": { "files.sample_json.donor.species": "Homo sapiens" } }, { "match": { "files.assay_json.single_cell.method": "Fluidigm C1" } }, { "match": { "files.sample_json.ncbi_biosample": "SAMN04303778" } } ] } } }, "subscription_id": "ba50df7b-5a97-4e87-b9ce-c0935a817f0b", "transaction_id": "ff6b7fa3-dc79-4a79-a313-296801de76b9", "match": { "bundle_version": "2017-08-03T041453.170646Z", "bundle_uuid": "4ce8a36d-51d6-4a3c-bae7-41a63699f877" } }' https://mitlxo7p17.execute-api.us-west-2.amazonaws.com/api/
+    #     post_notification()
+    #     twrite = es.get(id='123', index='test-index')
+    #     source = twrite['_source']
+    #     self.assertEqual(source, expected_index)
+    #     es.delete(id='123', index='test-index', doc_type='document')
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Updated mapping:
- Config file allows for text, keyword, long, etc. for ElasticSearch mapping.
- Strings can be mapped to be both text and keyword.
- Prepended name of file to fields to avoid key collision
Fixes #7 and #4 

Added test files:
- can run a local Flask (acting as Blue Box) and local ElasticSearch for local testing

Multiprocessing to app.py:
- added processing/threading to the "cron job" and when getting files

Replica change:
-  added env variable and ?replica param to Blue Box calls
Fixes #10 

Updated ReadMe