### PR TITLE
Updated Mapper for Gen3 Metadata Schema (First Pass, AZUL-5)

### DIFF
--- a/chalicelib/dcc/transformer.py
+++ b/chalicelib/dcc/transformer.py
@@ -143,7 +143,7 @@ class DCCJSONTransformer:
                 result = jmespath.search(dss_field, metadata)
             except IndexError as e:
                 log.error("The '{}' field doesn't exist in selected metadata".format(field))
-                exit()
+                raise
             return result
 
         if isinstance(dss_field, dict):

--- a/chalicelib/dcc/transformer.py
+++ b/chalicelib/dcc/transformer.py
@@ -2,7 +2,7 @@ import json
 import pprint
 import logging
 #TODO Check if APACHE LICENSE is OK to Use
-from jsonpath_rw import parse as jsonpath_parse
+import jmespath
 
 log = logging.getLogger(__name__)
 
@@ -123,15 +123,12 @@ class DCCJSONTransformer:
 
     def _find_value_with_fieldname(self, dss_field, metadata):
         def parse_metadata(field):
-            parser = jsonpath_parse("$..{}".format(field))
-            result = parser.find(metadata)
-
             try:
-                result_value = result[0].value
+                result = jmespath.search(dss_field, metadata)
             except IndexError as e:
-                log.error("The '{}' field doesn't exist in selected metadata".format(field), exec_info=True)
-                raise
-            return result_value
+                log.error("The '{}' field doesn't exist in selected metadata".format(field))
+                exit()
+            return result
 
         if isinstance(dss_field, dict):
             #TODO Implement seperator settings
@@ -140,8 +137,7 @@ class DCCJSONTransformer:
             return parse_metadata(dss_field)
 
     def _get_matching_subitem(self, dss_value, query_index_field, index_field, metadata):
-        parser = jsonpath_parse("$..{}".format(index_field))
-        result = parser.find(metadata)
+        result = jmespath.search(index_field, metadata)
         matching_subitems = [res.context.value for res in result]
         for subitem in matching_subitems:
             query_index_value = self._find_value_with_fieldname(query_index_field, subitem)

--- a/chalicelib/dcc/transformer.py
+++ b/chalicelib/dcc/transformer.py
@@ -54,6 +54,21 @@ class ConvertToListFormatter(Formatter):
             return value
 
 
+class ExtractFileExtension(Formatter):
+    name = "extract_file_extension"
+
+    def __init__(self):
+        super().__init__()
+
+    def format(self, value):
+        val_lst = value.split('.')
+
+        if val_lst:
+            return val_lst[-1]
+        else:
+            return "N/A"
+
+
 class DCCJSONTransformer:
     def __init__(self, filename):
         with open(filename, 'r') as csf:
@@ -62,6 +77,7 @@ class DCCJSONTransformer:
 
         self._formatters = {}
         self.add_formatter(ConvertToListFormatter())
+        self.add_formatter(ExtractFileExtension())
 
     def add_formatter(self, formatter):
         self._formatters[formatter.name] = formatter

--- a/chalicelib/dcc/transformer_mapping.json
+++ b/chalicelib/dcc/transformer_mapping.json
@@ -11,8 +11,8 @@
       },
       {
         "source": "metadata.json",
-        "index_field": "center_name",
-        "dss_field": "core_metadata.contributor"
+        "dss_field": "core_metadata.contributor",
+        "index_field": "center_name"
       },
       {
         "source": "metadata.json",
@@ -21,8 +21,8 @@
       },
       {
         "from_file_data": true,
-        "index_field": "lastModified",
-        "dss_field": "version"
+        "dss_field": "version",
+        "index_field": "lastModified"
       },
       {
         "source": "metadata.json",
@@ -40,8 +40,8 @@
       },
       {
         "source": "metadata.json",
-        "index_field": "file_type",
-        "dss_field": "core_metadata.format"
+        "dss_field": "core_metadata.format",
+        "index_field": "file_type"
       },
       {
         "from_file_data": true,
@@ -50,18 +50,18 @@
       },
       {
         "from_file_data": true,
-        "index_field": "file_id",
-        "dss_field": "uuid"
+        "dss_field": "uuid",
+        "index_field": "file_id"
       },
       {
         "from_file_data": true,
-        "index_field": "file_version",
-        "dss_field": "version"
+        "dss_field": "version",
+        "index_field": "file_version"
       },
       {
         "from_file_data": true,
-        "index_field": "fileMd5sum",
-        "dss_field": "sha1"
+        "dss_field": "sha1",
+        "index_field": "fileMd5sum"
       },
       {
         "from_file_data": true,
@@ -70,8 +70,8 @@
       },
       {
         "source": "metadata.json",
-        "index_field": "experimentalStrategy",
-        "dss_field": "aliquot.experimental_strategy"
+        "dss_field": "aliquot.experimental_strategy",
+        "index_field": "experimentalStrategy"
       },
       {
         "constant": "",
@@ -108,8 +108,8 @@
       },
       {
         "source": "metadata.json",
-        "index_field": "sampleId",
-        "dss_field": "sample.id"
+        "dss_field": "sample.id",
+        "index_field": "sampleId"
       },
       {
         "constant": "",
@@ -117,13 +117,13 @@
       },
       {
         "source": "metadata.json",
-        "index_field": "specimen_type",
-        "dss_field": "sample.biospecimen_type"
+        "dss_field": "sample.biospecimen_type",
+        "index_field": "specimen_type"
       },
       {
         "source": "metadata.json",
-        "index_field": "study",
-        "dss_field": "core_metadata.project_id"
+        "dss_field": "core_metadata.project_id",
+        "index_field": "study"
       },
       {
         "constant": "",
@@ -131,13 +131,13 @@
       },
       {
         "source": "metadata.json",
-        "index_field": "submittedSampleId",
-        "dss_field": "aliquot.submitter_id"
+        "dss_field": "aliquot.submitter_id",
+        "index_field": "submittedSampleId"
       },
       {
         "source": "metadata.json",
-        "index_field": "specimenUUID",
-        "dss_field": "sample.id"
+        "dss_field": "sample.id",
+        "index_field": "specimenUUID"
       },
       {
         "constant": "",
@@ -145,8 +145,8 @@
       },
       {
         "source": "metadata.json",
-        "index_field": "submitterDonorPrimarySite",
-        "dss_field": "sample.composition"
+        "dss_field": "sample.composition",
+        "index_field": "submitterDonorPrimarySite"
       },
       {
         "constant": "",
@@ -154,13 +154,13 @@
       },
       {
         "from_file_data": true,
-        "index_field": "title",
-        "dss_field": "name"
+        "dss_field": "name",
+        "index_field": "title"
       },
       {
         "from_file_data": true,
-        "index_field": "file_type",
         "dss_field": "name",
+        "index_field": "file_type",
         "formatters": ["extract_file_extension"]
       },
       {
@@ -169,8 +169,8 @@
       },
       {
         "from_file_data": true,
-        "index_field": "urls",
         "dss_field": "url",
+        "index_field": "urls",
         "formatters": ["convert_to_list"]
       },
       {

--- a/chalicelib/dcc/transformer_mapping.json
+++ b/chalicelib/dcc/transformer_mapping.json
@@ -6,19 +6,37 @@
         "index_field": "access"
       },
       {
+        "constant": "",
+        "dss_field": "analysis_type"
+      },
+      {
         "source": "metadata.json",
         "index_field": "center_name",
         "dss_field": "core_metadata.contributor"
       },
       {
         "source": "metadata.json",
-        "dss_field": "project_id",
-        "index_field": "core_metadata.project"
+        "dss_field": "core_metadata.project",
+        "index_field": "project_id"
       },
       {
         "from_file_data": true,
         "index_field": "lastModified",
         "dss_field": "version"
+      },
+      {
+        "source": "metadata.json",
+        "dss_field": "core_metadata.project",
+        "index_field": "program"
+      },
+      {
+        "source": "metadata.json",
+        "dss_field": "core_metadata.project",
+        "index_field": "project"
+      },
+      {
+        "constant": "",
+        "index_field": "redwoodDonorUUID"
       },
       {
         "source": "metadata.json",
@@ -28,7 +46,7 @@
       {
         "from_file_data": true,
         "dss_field": "size",
-        "index_field": "file_size"
+        "index_field": "fileSize"
       },
       {
         "from_file_data": true,
@@ -54,6 +72,10 @@
         "source": "metadata.json",
         "index_field": "experimentalStrategy",
         "dss_field": "aliquot.experimental_strategy"
+      },
+      {
+        "constant": "",
+        "index_field": "donor"
       },
       {
         "constant": "",

--- a/chalicelib/dcc/transformer_mapping.json
+++ b/chalicelib/dcc/transformer_mapping.json
@@ -25,8 +25,7 @@
         "index_field": "lastModified"
       },
       {
-        "source": "metadata.json",
-        "dss_field": "core_metadata.project",
+        "constant": "TOPMed",
         "index_field": "program"
       },
       {

--- a/chalicelib/dcc/transformer_mapping.json
+++ b/chalicelib/dcc/transformer_mapping.json
@@ -7,47 +7,28 @@
       },
       {
         "source": "metadata.json",
-        "index_field": "analysis_type",
-        "dss_field": "analysis_type"
+        "index_field": "center_name",
+        "dss_field": "contributor"
       },
       {
         "source": "metadata.json",
-        "dss_field": "center_name",
-        "index_field": "center_name"
-      },
-      {
-        "source": "metadata.json",
-        "dss_field": "donor_uuid",
-        "index_field": "redwoodDonorUUID"
-      },
-      {
-        "source": "metadata.json",
-        "dss_field": "project",
+        "dss_field": "project_id",
         "index_field": "project"
       },
       {
-        "source": "metadata.json",
-        "index_field": "program",
-        "dss_field": "program"
-      },
-      {
-        "source": "metadata.json",
+        "from_file_data": true,
         "index_field": "lastModified",
-        "dss_field": "timestamp"
+        "dss_field": "version"
       },
       {
         "source": "metadata.json",
         "index_field": "file_type",
-        "dss_field": "file_type",
-        "filter": [{
-          "data_file_field": "name",
-          "metadata_field": "file_path"
-        }]
+        "dss_field": "format"
       },
       {
         "from_file_data": true,
         "dss_field": "size",
-        "index_field": "fileSize"
+        "index_field": "file_size"
       },
       {
         "from_file_data": true,
@@ -65,31 +46,21 @@
         "dss_field": "sha1"
       },
       {
-        "source": "metadata.json",
-        "index_field": "experimentalStrategy",
-        "dss_field": "submitter_experimental_design"
-      },
-      {
-        "source": "metadata.json",
-        "dss_field": "bundle_uuid",
+        "from_file_data": true,
+        "dss_field": "uuid",
         "index_field": "download_id"
       },
       {
         "source": "metadata.json",
-        "index_field": "donor",
-        "dss_field": "donor_uuid"
-      },
-      {
-        "source": "metadata.json",
-        "index_field": "redwoodDonorUUID",
-        "dss_field": "donor_uuid"
+        "index_field": "experimentalStrategy",
+        "dss_field": "experimental_strategy"
       },
       {
         "constant": "",
         "index_field": "repoBaseUrl"
       },
       {
-        "constant": "Redwood-AWS-Oregon",
+        "constant": "DSS-AWS-Oregon",
         "index_field": "repoCode"
       },
       {
@@ -97,12 +68,12 @@
         "index_field": "repoCountry"
       },
       {
-        "source": "metadata.json",
-        "dss_field": "bundle_uuid",
+        "from_file_data": true,
+        "dss_field": "uuid",
         "index_field": "repoDataBundleId"
       },
       {
-        "constant": "Redwood-AWS-Oregon",
+        "constant": "DSS-AWS-Oregon",
         "index_field": "repoName"
       },
       {
@@ -110,58 +81,50 @@
         "index_field": "repoOrg"
       },
       {
-        "constant": "Blue Box",
+        "constant": "HCA DSS",
         "index_field": "repoType"
       },
       {
         "source": "metadata.json",
         "index_field": "sampleId",
-        "dss_field": "sample_uuid"
+        "dss_field": "id"
+      },
+      {
+        "constant": "",
+        "index_field": "software"
       },
       {
         "source": "metadata.json",
-        "index_field": "software",
-        "dss_field": "workflow_name"
-      },
-      {
-        "source": "metadata.json",
-        "index_field": "software",
-        "dss_field": "workflow_name"
-      },
-      {
-        "source": "metadata.json",
-        "dss_field": "submitter_specimen_type",
+        "dss_field": "biospecimen_type",
         "index_field": "specimen_type"
       },
       {
         "source": "metadata.json",
         "index_field": "study",
-        "dss_field": "project"
+        "dss_field": "project_id"
       },
       {
-        "source": "metadata.json",
-        "index_field": "submittedDonorId",
-        "dss_field": "submitter_donor_id"
+        "constant": "",
+        "index_field": "submittedDonorId"
       },
       {
         "source": "metadata.json",
         "index_field": "submittedSampleId",
-        "dss_field": "submitter_sample_id"
+        "dss_field": "submitter_id"
       },
       {
         "source": "metadata.json",
         "index_field": "specimenUUID",
-        "dss_field": "specimen_uuid"
+        "dss_field": "id"
       },
       {
-        "source": "metadata.json",
-        "index_field": "submittedSpecimenId",
-        "dss_field": "submitter_specimen_id"
+        "constant": "",
+        "index_field": "submittedSpecimenId"
       },
       {
         "source": "metadata.json",
         "index_field": "submitterDonorPrimarySite",
-        "dss_field": "submitter_donor_primary_site"
+        "dss_field": "composition"
       },
       {
         "constant": "",
@@ -173,15 +136,8 @@
         "dss_field": "name"
       },
       {
-        "source": "metadata.json",
-        "index_field": "workflow",
-        "dss_field": {
-          "field_names": [
-            "workflow_name",
-            "workflow_version"
-          ],
-          "separator": ":"
-        }
+        "constant": "",
+        "index_field": "workflow"
       },
       {
         "from_file_data": true,
@@ -190,9 +146,8 @@
         "formatters": ["convert_to_list"]
       },
       {
-        "source": "metadata.json",
-        "index_field": "workflowVersion",
-        "dss_field": "workflow_version"
+        "constant": "",
+        "index_field": "workflowVersion"
       },
       {
         "constant": "",

--- a/chalicelib/dcc/transformer_mapping.json
+++ b/chalicelib/dcc/transformer_mapping.json
@@ -7,7 +7,7 @@
       },
       {
         "constant": "",
-        "dss_field": "analysis_type"
+        "index_field": "analysis_type"
       },
       {
         "source": "metadata.json",
@@ -16,8 +16,8 @@
       },
       {
         "source": "metadata.json",
-        "dss_field": "core_metadata.project",
-        "index_field": "project_id"
+        "dss_field": "core_metadata.project_id",
+        "index_field": "project"
       },
       {
         "from_file_data": true,
@@ -30,18 +30,8 @@
         "index_field": "program"
       },
       {
-        "source": "metadata.json",
-        "dss_field": "core_metadata.project",
-        "index_field": "project"
-      },
-      {
         "constant": "",
         "index_field": "redwoodDonorUUID"
-      },
-      {
-        "source": "metadata.json",
-        "dss_field": "core_metadata.format",
-        "index_field": "file_type"
       },
       {
         "from_file_data": true,

--- a/chalicelib/dcc/transformer_mapping.json
+++ b/chalicelib/dcc/transformer_mapping.json
@@ -136,6 +136,12 @@
         "dss_field": "name"
       },
       {
+        "from_file_data": true,
+        "index_field": "file_type",
+        "dss_field": "name",
+        "formatters": ["extract_file_extension"]
+      },
+      {
         "constant": "",
         "index_field": "workflow"
       },

--- a/chalicelib/dcc/transformer_mapping.json
+++ b/chalicelib/dcc/transformer_mapping.json
@@ -8,12 +8,12 @@
       {
         "source": "metadata.json",
         "index_field": "center_name",
-        "dss_field": "contributor"
+        "dss_field": "core_metadata.contributor"
       },
       {
         "source": "metadata.json",
         "dss_field": "project_id",
-        "index_field": "project"
+        "index_field": "core_metadata.project"
       },
       {
         "from_file_data": true,
@@ -23,7 +23,7 @@
       {
         "source": "metadata.json",
         "index_field": "file_type",
-        "dss_field": "format"
+        "dss_field": "core_metadata.format"
       },
       {
         "from_file_data": true,
@@ -53,7 +53,7 @@
       {
         "source": "metadata.json",
         "index_field": "experimentalStrategy",
-        "dss_field": "experimental_strategy"
+        "dss_field": "aliquot.experimental_strategy"
       },
       {
         "constant": "",
@@ -87,7 +87,7 @@
       {
         "source": "metadata.json",
         "index_field": "sampleId",
-        "dss_field": "id"
+        "dss_field": "sample.id"
       },
       {
         "constant": "",
@@ -95,13 +95,13 @@
       },
       {
         "source": "metadata.json",
-        "dss_field": "biospecimen_type",
-        "index_field": "specimen_type"
+        "index_field": "specimen_type",
+        "dss_field": "sample.biospecimen_type"
       },
       {
         "source": "metadata.json",
         "index_field": "study",
-        "dss_field": "project_id"
+        "dss_field": "core_metadata.project_id"
       },
       {
         "constant": "",
@@ -110,12 +110,12 @@
       {
         "source": "metadata.json",
         "index_field": "submittedSampleId",
-        "dss_field": "submitter_id"
+        "dss_field": "aliquot.submitter_id"
       },
       {
         "source": "metadata.json",
         "index_field": "specimenUUID",
-        "dss_field": "id"
+        "dss_field": "sample.id"
       },
       {
         "constant": "",
@@ -124,7 +124,7 @@
       {
         "source": "metadata.json",
         "index_field": "submitterDonorPrimarySite",
-        "dss_field": "composition"
+        "dss_field": "sample.composition"
       },
       {
         "constant": "",

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ botocore==1.8.13
 chalice==1.1.0
 elasticsearch>=5.0.0,<6.0.0
 future==0.16.0
-hca==3.3.0
+hca >= 3.5.1, < 4


### PR DESCRIPTION
Update the Azul indexer mappings for metadata exported from the UChicago Gen3 system for the TOPMed 107 open access data set.

Also changed transformer mappings to be fully qualified JSON paths, and changed the transformer implementation from using jsonpath to using jmespath.