### PR TITLE
Include "aliases" field from file data in the index

### DIFF
--- a/chalicelib/dcc/transformer_mapping.json
+++ b/chalicelib/dcc/transformer_mapping.json
@@ -58,6 +58,11 @@
         "index_field": "download_id"
       },
       {
+        "from_file_data": true,
+        "dss_field": "aliases",
+        "index_field": "aliases"
+      },
+      {
         "source": "metadata.json",
         "dss_field": "aliquot.experimental_strategy",
         "index_field": "experimentalStrategy"


### PR DESCRIPTION
Commons KC2 GUIDs are now loaded into the HCA DSS as the `aliases` field in the data file information. Include the `aliases` field in the transformer mappings so that the GUID and any other alias values are available in the Elasticsearch index to be consumed by dashboard-service/boardwalk.