### PR TITLE
Added mappings for index fields: donor, specimenUUID and sampleId

### DIFF
--- a/chalicelib/dcc/transformer_mapping.json
+++ b/chalicelib/dcc/transformer_mapping.json
@@ -174,6 +174,21 @@
       {
         "constant": "",
         "index_field": "metadataJson"
+      },
+      {
+        "source": "metadata.json",
+        "dss_field": "case.node_id",
+        "index_field": "donor"
+      },
+      {
+        "source": "metadata.json",
+        "dss_field": "sample.node_id",
+        "index_field": "specimenUUID"
+      },
+      {
+        "source": "metadata.json",
+        "dss_field": "aliquot.node_id",
+        "index_field": "sampleId"
       }]
     }]
 }


### PR DESCRIPTION
Added new mappings for Gen3 TOPMed 107 metadata to the
existing "Spinnaker" metadata fields as follows:
	case.node_id -> donor
	sample.node_id -> specimenUUID
	aliquot.node_id -> sampleId