### PR TITLE
Add utility for automatically sourcing `environment` into virtualenv

### DIFF
--- a/scripts/envhook.py
+++ b/scripts/envhook.py
@@ -1,0 +1,74 @@
+import errno
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+__all__ = ('setenv', 'main')
+
+
+def main(argv):
+    import argparse
+    parser = argparse.ArgumentParser(description='Install a hook into Python that automatically sources `environment`')
+    parser.add_argument('action', choices=['install', 'remove'])
+    options = parser.parse_args(argv)
+    import site
+    if hasattr(sys, 'real_prefix'):
+        # virtualenv's site does not have getsitepackages()
+        link_dir = os.path.abspath(os.path.join(os.path.dirname(site.__file__), 'site-packages'))
+    else:
+        raise RuntimeError('Need to be run from within a virtualenv')
+    link = os.path.join(link_dir, 'sitecustomize.py')
+    dst = os.path.abspath(__file__)
+    dst = os.path.relpath(dst, link_dir)
+    try:
+        cur_dst = os.readlink(link)
+    except FileNotFoundError:
+        cur_dst = None
+    except OSError as e:
+        if e.errno == errno.EINVAL:
+            raise RuntimeError(f"{link} is not a symbolic link. It may be a 3rd party file and we won't touch it")
+        else:
+            raise
+    if options.action == 'install':
+        if cur_dst is None:
+            os.symlink(dst, link)
+        elif dst == cur_dst:
+            pass
+        else:
+            raise RuntimeError(f'{link} points somewhere unexpected ({cur_dst})')
+    elif options.action == 'remove':
+        if cur_dst is None:
+            pass
+        elif cur_dst == dst:
+            os.unlink(link)
+        else:
+            raise RuntimeError(f'{link} points somewhere unexpected ({cur_dst})')
+    else:
+        assert False
+
+
+def setenv():
+    self = Path(__file__).resolve()
+    project = self.parent.parent
+    environment = project.joinpath('environment')
+    before = _parse(_run('env'))
+    after = _parse(_run(f'source {environment} && env'))
+    diff = set(after.items()).symmetric_difference(before.items())
+    for k, v in diff:
+        print(f"Setting {k}={v}", file=sys.stderr)
+        os.environ[k] = v
+
+
+def _run(command) -> str:
+    return subprocess.run(command, stdout=subprocess.PIPE, shell=True).stdout.decode()
+
+
+def _parse(env: str):
+    return {k: v for k, _, v in (line.partition('=') for line in env.splitlines())}
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])
+elif __name__ == 'sitecustomize':
+    setenv()


### PR DESCRIPTION
Works great with PyCharm, eliminates the need to launch PyCharm with `source environment; charm` and last but not least allows for having multiple PyCharm project open, each with their own `environment`.